### PR TITLE
Remove sqflite_common_ffi dependency to eliminate Windows build dependency

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:novelty/router/router.dart';
 import 'package:novelty/utils/settings_provider.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 Future<void> main() async {
-  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
-  }
-
   runApp(
     const ProviderScope(
       child: MyApp(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   riverpod_annotation: ^3.0.0-dev.16
   shared_preferences: ^2.5.3
   sqflite: ^2.3.4
-  sqflite_common_ffi: ^2.3.6
 
 dev_dependencies:
   build_runner: ^2.5.4


### PR DESCRIPTION
## Changes

This PR removes the dependency on `sqflite_common_ffi` to eliminate Windows build dependencies, as requested.

### What was changed:

1. Removed `sqflite_common_ffi` dependency from `pubspec.yaml`
2. Removed the import and initialization code from `main.dart`:
   - Removed the import statement for `sqflite_common_ffi`
   - Removed the platform-specific initialization code that was using `sqfliteFfiInit()` and `databaseFactoryFfi`

### Impact:

- The application will no longer use the FFI implementation for desktop platforms
- This simplifies the build process by removing Windows-specific dependencies
- The regular `sqflite` package is still available for mobile platforms

### Testing:

These changes should be tested on mobile platforms to ensure database functionality continues to work as expected.


@L4Ph can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d5756a94b32d41e798e7229b19819fc7)