### PR TITLE
Fix: Short story display issue when Episodes list is empty

### DIFF
--- a/lib/screens/novel_detail_page.dart
+++ b/lib/screens/novel_detail_page.dart
@@ -45,8 +45,7 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
       });
 
       // 短編小説の場合は本文も取得
-      // novelTypeがnullまたは2の場合は短編小説として扱う
-      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
+      if (novelInfo.novelType == 2) {
         final episode = await _apiService.fetchEpisode(widget.ncode, 1);
         if (!mounted) return;
         setState(() {
@@ -118,8 +117,7 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
     final novelInfo = _novelInfo!;
 
     // 短編小説の場合は本文を表示
-    // novelTypeがnullまたは2の場合は短編小説として扱う
-    if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
+    if (novelInfo.novelType == 2) {
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(

--- a/lib/screens/novel_detail_page.dart
+++ b/lib/screens/novel_detail_page.dart
@@ -144,6 +144,24 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
     
     // エピソードリストが空の場合は、短編小説として扱う
     if (novelInfo.episodes == null || novelInfo.episodes!.isEmpty) {
+      // 短編小説の場合は本文を取得して表示
+      if (_shortStoryEpisode == null) {
+        // まだ本文を取得していない場合は取得を開始
+        _apiService.fetchEpisode(widget.ncode, 1).then((episode) {
+          if (mounted) {
+            setState(() {
+              _shortStoryEpisode = episode;
+            });
+          }
+        }).catchError((error) {
+          if (mounted) {
+            setState(() {
+              _errorMessage = 'エラーが発生しました: $error';
+            });
+          }
+        });
+      }
+      
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(
@@ -158,11 +176,15 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
             ),
           ],
         ),
-        body: NovelContent(
-          ncode: widget.ncode,
-          episode: 1,
-          initialData: null,
-        ),
+        body: _errorMessage.isNotEmpty
+            ? Center(child: Text(_errorMessage))
+            : (_shortStoryEpisode == null
+                ? const Center(child: CircularProgressIndicator())
+                : NovelContent(
+                    ncode: widget.ncode,
+                    episode: 1,
+                    initialData: _shortStoryEpisode,
+                  )),
       );
     }
 
@@ -229,10 +251,15 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
                     // エピソードのURLから番号を抽出
                     final episodeUrl = episode.url;
                     if (episodeUrl != null) {
-                      final match = RegExp(r'/(\d+)/$').firstMatch(episodeUrl);
-                      if (match != null) {
-                        final episodeNumber = match.group(1);
-                        context.push('/novel/${widget.ncode}/$episodeNumber');
+                      // 短編小説の場合は特別な処理
+                      if (novelInfo.novelType == 2) {
+                        context.push('/novel/${widget.ncode}');
+                      } else {
+                        final match = RegExp(r'/(\d+)/$').firstMatch(episodeUrl);
+                        if (match != null) {
+                          final episodeNumber = match.group(1);
+                          context.push('/novel/${widget.ncode}/$episodeNumber');
+                        }
                       }
                     }
                   },

--- a/lib/screens/novel_detail_page.dart
+++ b/lib/screens/novel_detail_page.dart
@@ -45,7 +45,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
       });
 
       // 短編小説の場合は本文も取得
-      if (novelInfo.novelType == 2) {
+      // novelTypeがnullまたは2の場合は短編小説として扱う
+      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
         final episode = await _apiService.fetchEpisode(widget.ncode, 1);
         if (!mounted) return;
         setState(() {
@@ -117,7 +118,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
     final novelInfo = _novelInfo!;
 
     // 短編小説の場合は本文を表示
-    if (novelInfo.novelType == 2) {
+    // novelTypeがnullまたは2の場合は短編小説として扱う
+    if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(

--- a/lib/screens/novel_detail_page.dart
+++ b/lib/screens/novel_detail_page.dart
@@ -44,8 +44,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
         _novelInfo = novelInfo;
       });
 
-      // 短編小説の場合は本文も取得
-      if (novelInfo.novelType == 2) {
+      // 短編小説の場合、または小説タイプが不明な場合は本文も取得
+      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
         final episode = await _apiService.fetchEpisode(widget.ncode, 1);
         if (!mounted) return;
         setState(() {
@@ -116,8 +116,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
 
     final novelInfo = _novelInfo!;
 
-    // 短編小説の場合は本文を表示
-    if (novelInfo.novelType == 2) {
+    // 短編小説の場合、または小説タイプが不明な場合は本文を表示
+    if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(
@@ -139,6 +139,30 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
                 episode: 1,
                 initialData: _shortStoryEpisode,
               ),
+      );
+    }
+    
+    // エピソードリストが空の場合は、短編小説として扱う
+    if (novelInfo.episodes == null || novelInfo.episodes!.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.pop(),
+          ),
+          title: Text(novelInfo.title ?? ''),
+          actions: [
+            IconButton(
+              icon: Icon(_isInLibrary ? Icons.favorite : Icons.favorite_border),
+              onPressed: _toggleLibraryStatus,
+            ),
+          ],
+        ),
+        body: NovelContent(
+          ncode: widget.ncode,
+          episode: 1,
+          initialData: null,
+        ),
       );
     }
 

--- a/lib/screens/novel_detail_page.dart
+++ b/lib/screens/novel_detail_page.dart
@@ -44,8 +44,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
         _novelInfo = novelInfo;
       });
 
-      // 短編小説の場合、または小説タイプが不明な場合は本文も取得
-      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
+      // 短編小説の場合は本文も取得
+      if (novelInfo.novelType == 2) {
         final episode = await _apiService.fetchEpisode(widget.ncode, 1);
         if (!mounted) return;
         setState(() {
@@ -116,8 +116,8 @@ class _NovelDetailPageState extends State<NovelDetailPage> {
 
     final novelInfo = _novelInfo!;
 
-    // 短編小説の場合、または小説タイプが不明な場合は本文を表示
-    if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
+    // 短編小説の場合は本文を表示
+    if (novelInfo.novelType == 2) {
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(

--- a/lib/screens/novel_page.dart
+++ b/lib/screens/novel_page.dart
@@ -52,11 +52,15 @@ class _NovelPageState extends State<NovelPage> {
         return;
       }
 
-      // 短編小説の場合はエピソード指定でのアクセスは無効
+      // 短編小説の場合は、エピソード番号を1として扱う
       if (novelInfo.novelType == 2) {
         setState(() {
-          _errorMessage = '短編小説にはエピソード番号でアクセスできません';
+          _currentEpisode = 1;
+          _novelTitle = novelInfo.title ?? '';
+          _totalEpisodes = 1;
+          _novelType = novelInfo.novelType;
         });
+        await _fetchEpisodeData(1);
         return;
       }
 

--- a/lib/screens/novel_page.dart
+++ b/lib/screens/novel_page.dart
@@ -53,7 +53,8 @@ class _NovelPageState extends State<NovelPage> {
       }
 
       // 短編小説の場合は、エピソード番号を1として扱う
-      if (novelInfo.novelType == 2) {
+      // novelTypeがnullまたは2の場合は短編小説として扱う
+      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
         setState(() {
           _currentEpisode = 1;
           _novelTitle = novelInfo.title ?? '';
@@ -127,7 +128,7 @@ class _NovelPageState extends State<NovelPage> {
   Widget build(BuildContext context) {
     final appBarTitle = _episodeSubtitle.isEmpty
         ? _novelTitle
-        : (_novelType == 2
+        : (_novelType == 2 || _novelType == null
               ? _episodeSubtitle
               : '$_novelTitle - $_episodeSubtitle');
 

--- a/lib/screens/novel_page.dart
+++ b/lib/screens/novel_page.dart
@@ -53,8 +53,7 @@ class _NovelPageState extends State<NovelPage> {
       }
 
       // 短編小説の場合は、エピソード番号を1として扱う
-      // novelTypeがnullまたは2の場合は短編小説として扱う
-      if (novelInfo.novelType == 2 || novelInfo.novelType == null) {
+      if (novelInfo.novelType == 2) {
         setState(() {
           _currentEpisode = 1;
           _novelTitle = novelInfo.title ?? '';
@@ -128,7 +127,7 @@ class _NovelPageState extends State<NovelPage> {
   Widget build(BuildContext context) {
     final appBarTitle = _episodeSubtitle.isEmpty
         ? _novelTitle
-        : (_novelType == 2 || _novelType == null
+        : (_novelType == 2
               ? _episodeSubtitle
               : '$_novelTitle - $_episodeSubtitle');
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -62,7 +62,8 @@ class ApiService {
     final info = await _fetchNovelInfoFromNarou(ncode);
 
     // 短編小説の場合は、単一のエピソードとして扱う
-    if (info.novelType == 2) {
+    // novelTypeがnullまたは2の場合は短編小説として扱う
+    if (info.novelType == 2 || info.novelType == null) {
       // 短編小説の場合は、単一のエピソードとして扱う
       info.episodes = [
         Episode(
@@ -128,13 +129,15 @@ class ApiService {
 
   Future<Episode> fetchEpisode(String ncode, int episode) async {
     final info = await _fetchNovelInfoFromNarou(ncode);
-    final isShortStory = info.novelType == 2;
+    // novelTypeがnullまたは2の場合は短編小説として扱う
+    final isShortStory = info.novelType == 2 || info.novelType == null;
 
     // 短編小説の場合、episode が 1 以外は無効
     if (isShortStory && episode != 1) {
       throw Exception('短編小説にはエピソード番号 $episode は存在しません');
     }
 
+    // 短編小説の場合は、エピソード番号を含まないURLを使用する
     final url = isShortStory
         ? 'https://ncode.syosetu.com/${ncode.toLowerCase()}/'
         : 'https://ncode.syosetu.com/${ncode.toLowerCase()}/$episode/';

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -61,8 +61,17 @@ class ApiService {
   Future<NovelInfo> fetchNovelInfo(String ncode) async {
     final info = await _fetchNovelInfoFromNarou(ncode);
 
-    if (info.novelType == 2) {
-      info.episodes = [];
+    // 短編小説の場合、または小説タイプが不明な場合は、単一のエピソードとして扱う
+    if (info.novelType == 2 || info.novelType == null) {
+      // 短編小説の場合は、単一のエピソードとして扱う
+      info.episodes = [
+        Episode(
+          subtitle: info.title,
+          url: 'https://ncode.syosetu.com/${ncode.toLowerCase()}/',
+          ncode: ncode,
+          index: 1,
+        )
+      ];
       return info;
     }
 
@@ -119,7 +128,8 @@ class ApiService {
 
   Future<Episode> fetchEpisode(String ncode, int episode) async {
     final info = await _fetchNovelInfoFromNarou(ncode);
-    final isShortStory = info.novelType == 2;
+    // novelTypeが設定されていない場合も短編として扱う可能性を考慮
+    final isShortStory = info.novelType == 2 || info.novelType == null;
 
     // 短編小説の場合、episode が 1 以外は無効
     if (isShortStory && episode != 1) {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -61,8 +61,8 @@ class ApiService {
   Future<NovelInfo> fetchNovelInfo(String ncode) async {
     final info = await _fetchNovelInfoFromNarou(ncode);
 
-    // 短編小説の場合、または小説タイプが不明な場合は、単一のエピソードとして扱う
-    if (info.novelType == 2 || info.novelType == null) {
+    // 短編小説の場合は、単一のエピソードとして扱う
+    if (info.novelType == 2) {
       // 短編小説の場合は、単一のエピソードとして扱う
       info.episodes = [
         Episode(
@@ -128,8 +128,7 @@ class ApiService {
 
   Future<Episode> fetchEpisode(String ncode, int episode) async {
     final info = await _fetchNovelInfoFromNarou(ncode);
-    // novelTypeが設定されていない場合も短編として扱う可能性を考慮
-    final isShortStory = info.novelType == 2 || info.novelType == null;
+    final isShortStory = info.novelType == 2;
 
     // 短編小説の場合、episode が 1 以外は無効
     if (isShortStory && episode != 1) {


### PR DESCRIPTION
## 問題点
短編小説の際に、Episodesが空のリストが原因で、目次が空になってしまい、小説が表示されない問題がありました。

## 修正内容
1. `ApiService.fetchNovelInfo`メソッドを修正し、短編小説（novelType == 2）の場合に、単一のエピソードを含むリストを作成するようにしました。これにより、Episodesリストが空になることを防ぎます。

2. `ApiService.fetchEpisode`メソッドを修正し、短編小説の場合の処理を改善しました。

3. `NovelDetailPage`クラスを修正し、短編小説の場合の処理を改善しました。また、エピソードリストが空の場合のフォールバック処理も追加しました。

これらの変更により、短編小説が正しく表示されるようになり、ユーザーは短編小説の本文を読むことができるようになりました。

## 追加修正
- 前回の修正で、novelType=nullの場合も短編として扱うようにしていましたが、これにより連載小説（novelType=1）が正しく表示されなくなる問題が発生しました。
- 今回の修正では、novelType=2の場合のみ短編として扱うように変更し、連載小説の目次表示を復元しました。
- エピソードリストが空の場合のフォールバック処理は残しているため、短編小説の表示は引き続き正常に動作します。

## 最終修正
- 短編小説の場合、URLが `https://ncode.syosetu.com/{ncode}/` の形式であり、`{ncode}/1/` のような形式ではアクセスできないことが判明しました。
- `NovelPage`クラスを修正し、短編小説の場合は正しいURL形式でアクセスするようにしました。
- `NovelDetailPage`クラスも修正し、短編小説の場合に正しく本文を表示するようにしました。

## 追加修正 (2)
- APIから`novelType`がnullで返される場合があることが判明しました。
- `_fetchNovelInfoFromNarou`メソッドを修正し、APIから`novelType`がnullで返された場合にデフォルト値として1（連載小説）を設定するようにしました。
- これにより、連載小説と短編小説の両方が正しく表示されるようになりました。

## 追加修正 (3)
- APIから`novelType`がnullで返される場合に、連載小説と短編小説を区別する方法を改善しました。
- `general_all_no`（総話数）を使用して、総話数が1以下の場合は短編小説、それ以外は連載小説として扱うようにしました。
- これにより、APIから`novelType`が正しく取得できない場合でも、小説の種類を正確に判断できるようになりました。