### PR TITLE
AndroidのOSジェスチャーとの干渉問題を修正

### DIFF
--- a/lib/widgets/novel_content.dart
+++ b/lib/widgets/novel_content.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -90,23 +92,24 @@ class NovelContentBody extends HookWidget {
             );
 
             // システムジェスチャーエリアを考慮したパディング計算
-            // SafeAreaが既にpaddingを適用しているので、systemGestureInsetsのみを追加
+            // SafeAreaが既にpaddingを適用し、その上にsystemGestureInsetsを追加
+            // デスクトップ環境ではsystemGestureInsetsが0なので、最低16pxを確保
             final systemGestureInsets = MediaQuery.of(context).systemGestureInsets;
 
             // 縦書きモード用（横スクロール）: 左右端のバックジェスチャー領域を確保
             final verticalModePadding = EdgeInsets.only(
-              left: systemGestureInsets.left,
-              right: systemGestureInsets.right,
-              top: 0,
-              bottom: 0,
+              left: math.max(16.0, systemGestureInsets.left),
+              right: math.max(16.0, systemGestureInsets.right),
+              top: 16,
+              bottom: 16,
             );
 
             // 横書きモード用（縦スクロール）: 下端のホームジェスチャー領域を確保
             final horizontalModePadding = EdgeInsets.only(
-              left: 0,
-              right: 0,
-              top: 0,
-              bottom: systemGestureInsets.bottom,
+              left: 16,
+              right: 16,
+              top: 16,
+              bottom: math.max(16.0, systemGestureInsets.bottom),
             );
 
             if (settingsData.isVertical) {

--- a/test/screens/novel_detail_page_test.dart
+++ b/test/screens/novel_detail_page_test.dart
@@ -1,12 +1,180 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:novelty/models/episode.dart';
+import 'package:novelty/models/novel_info.dart';
+import 'package:novelty/repositories/novel_repository.dart';
+import 'package:novelty/screens/novel_detail_page.dart';
+import 'package:novelty/utils/settings_provider.dart';
 
-/// NovelDetailPageの履歴追加に関するテスト
+@GenerateMocks([NovelRepository])
+import 'novel_detail_page_test.mocks.dart';
+
+/// NovelDetailPageのテスト
 void main() {
   group('NovelDetailPage 履歴追加テスト', () {
     test('目次ページでは履歴に追加されない設計であることを確認', () {
       // この修正により、目次ページで履歴に追加されることはない
       // 実際の履歴追加はNovelPageでのみ実行される
       expect(true, isTrue);
+    });
+  });
+
+  group('NovelDetailPage 長押しメニューテスト', () {
+    late MockNovelRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockNovelRepository();
+    });
+
+    testWidgets('長押しでモーダルボトムシートが表示されること', (tester) async {
+      // モックのNovelInfoとEpisodeを作成
+      final novelInfo = NovelInfo(
+        ncode: 'n0000a',
+        title: 'テスト小説',
+        episodes: [
+          const Episode(
+            index: 1,
+            subtitle: 'テストエピソード',
+            isDownloaded: false,
+          ),
+        ],
+      );
+
+      when(mockRepository.getNovelInfo('n0000a'))
+          .thenAnswer((_) async => novelInfo);
+      when(mockRepository.getEpisodeList('n0000a_1'))
+          .thenAnswer((_) async => novelInfo.episodes!);
+
+      // ProviderScopeでモックを注入
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            novelRepositoryProvider.overrideWithValue(mockRepository),
+            settingsProvider.overrideWith((_) async => const AppSettings()),
+          ],
+          child: const MaterialApp(
+            home: NovelDetailPage(ncode: 'n0000a'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // エピソードのListTileを探す
+      final listTileFinder = find.byType(ListTile).first;
+      expect(listTileFinder, findsOneWidget);
+
+      // 長押しする
+      await tester.longPress(listTileFinder);
+      await tester.pumpAndSettle();
+
+      // モーダルボトムシートが表示されることを確認
+      expect(find.text('ダウンロード'), findsOneWidget);
+    });
+
+    testWidgets('ダウンロード済みエピソードの長押しで削除メニューが表示されること', (tester) async {
+      // モックのNovelInfoとEpisodeを作成（ダウンロード済み）
+      final novelInfo = NovelInfo(
+        ncode: 'n0000a',
+        title: 'テスト小説',
+        episodes: [
+          const Episode(
+            index: 1,
+            subtitle: 'テストエピソード',
+            isDownloaded: true,
+          ),
+        ],
+      );
+
+      when(mockRepository.getNovelInfo('n0000a'))
+          .thenAnswer((_) async => novelInfo);
+      when(mockRepository.getEpisodeList('n0000a_1'))
+          .thenAnswer((_) async => novelInfo.episodes!);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            novelRepositoryProvider.overrideWithValue(mockRepository),
+            settingsProvider.overrideWith((_) async => const AppSettings()),
+          ],
+          child: const MaterialApp(
+            home: NovelDetailPage(ncode: 'n0000a'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // エピソードのListTileを探す
+      final listTileFinder = find.byType(ListTile).first;
+
+      // 長押しする
+      await tester.longPress(listTileFinder);
+      await tester.pumpAndSettle();
+
+      // 削除メニューが表示されることを確認
+      expect(find.text('削除'), findsOneWidget);
+    });
+
+    testWidgets('長押しメニューからダウンロードが実行されること', (tester) async {
+      final novelInfo = NovelInfo(
+        ncode: 'n0000a',
+        title: 'テスト小説',
+        episodes: [
+          const Episode(
+            index: 1,
+            subtitle: 'テストエピソード',
+            isDownloaded: false,
+          ),
+        ],
+      );
+
+      when(mockRepository.getNovelInfo('n0000a'))
+          .thenAnswer((_) async => novelInfo);
+      when(mockRepository.getEpisodeList('n0000a_1'))
+          .thenAnswer((_) async => novelInfo.episodes!);
+      when(
+        mockRepository.downloadSingleEpisode(
+          'n0000a',
+          1,
+          revised: anyNamed('revised'),
+        ),
+      ).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            novelRepositoryProvider.overrideWithValue(mockRepository),
+            settingsProvider.overrideWith((_) async => const AppSettings()),
+          ],
+          child: const MaterialApp(
+            home: NovelDetailPage(ncode: 'n0000a'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // 長押しする
+      final listTileFinder = find.byType(ListTile).first;
+      await tester.longPress(listTileFinder);
+      await tester.pumpAndSettle();
+
+      // ダウンロードボタンをタップ
+      await tester.tap(find.text('ダウンロード'));
+      await tester.pumpAndSettle();
+
+      // downloadSingleEpisodeが呼ばれたことを確認
+      verify(
+        mockRepository.downloadSingleEpisode(
+          'n0000a',
+          1,
+          revised: anyNamed('revised'),
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
- Dismissibleウィジェットを削除してシステムバックジェスチャーとの競合を解消
- エピソードの削除/ダウンロード操作を長押しメニューに変更
- システムジェスチャーエリアを考慮したパディングを追加
  - 縦書きモード: 左右端にsystemGestureInsets分のパディングを追加
  - 横書きモード: 下端にsystemGestureInsets分のパディングを追加
- これによりバックジェスチャー、ホームジェスチャーが正常に機能

https://claude.ai/code/session_016nndhFeNNMVJnuUTftXAeK