### PR TITLE
add Android SDK with CI

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -137,6 +137,9 @@ jobs:
         with:
           cache: true
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@651bceb6f9ca583f16b8d75b62c36ded2ae6fc9c # v4.0.0
+
       - name: Get Flutter packages
         run: mise run get
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * CI/CDパイプラインを改善しました。Androidアプリケーションのビルド準備におけるAndroid SDKの自動セットアップを有効にし、ビルドプロセスをより堅牢にしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->