### PR TITLE
縦書き表示時にimmersiveStickyモードを設定

### DIFF
--- a/lib/widgets/novel_content.dart
+++ b/lib/widgets/novel_content.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:narou_parser/narou_parser.dart';
@@ -80,6 +82,37 @@ class NovelContentBody extends HookWidget {
       return brightness == Brightness.dark ? Colors.white : Colors.black;
     }, [Theme.of(context).brightness]);
 
+    // 縦書き/横書きに応じてイマーシブモードを設定
+    useEffect(() {
+      Future<void> setUiMode(AppSettings data) async {
+        try {
+          final mode = data.isVertical
+              ? SystemUiMode.immersiveSticky
+              : SystemUiMode.edgeToEdge;
+          await SystemChrome.setEnabledSystemUIMode(mode);
+        } on PlatformException catch (e, s) {
+          // プラットフォームチャネルのエラーをログに出力
+          debugPrint('Failed to set SystemUIMode: $e\n$s');
+        }
+      }
+
+      // settingsがデータを持っている場合のみUIモードを設定
+      if (settings.hasValue) {
+        unawaited(setUiMode(settings.requireValue));
+      }
+
+      // クリーンアップ: ウィジェット破棄時はedgeToEdgeに戻す
+      return () {
+        unawaited(
+          SystemChrome.setEnabledSystemUIMode(
+            SystemUiMode.edgeToEdge,
+          ).catchError((Object e, StackTrace s) {
+            debugPrint('Failed to reset SystemUIMode on dispose: $e\n$s');
+          }),
+        );
+      };
+    }, [settings]);
+
     return settings.when(
       data: (settingsData) {
         return content.when(
@@ -94,7 +127,9 @@ class NovelContentBody extends HookWidget {
             // システムジェスチャーエリアを考慮したパディング計算
             // SafeAreaが既にpaddingを適用し、その上にsystemGestureInsetsを追加
             // デスクトップ環境ではsystemGestureInsetsが0なので、最低16pxを確保
-            final systemGestureInsets = MediaQuery.of(context).systemGestureInsets;
+            final systemGestureInsets = MediaQuery.of(
+              context,
+            ).systemGestureInsets;
 
             // 縦書きモード用（横スクロール）: 左右端のバックジェスチャー領域を確保
             final verticalModePadding = EdgeInsets.only(

--- a/test/widgets/novel_content_test.dart
+++ b/test/widgets/novel_content_test.dart
@@ -107,4 +107,48 @@ void main() {
     expect(find.byType(TategakiText), findsOneWidget);
     expect(find.byType(NovelContentView), findsNothing);
   });
+
+  testWidgets('縦書き設定でTategakiTextがレンダリングされること', (tester) async {
+    await pumpWidget(
+      tester,
+      contentValue: AsyncData(testContent),
+      settingsValue: AsyncData(defaultTestSettings.copyWith(isVertical: true)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TategakiText), findsOneWidget);
+  });
+
+  testWidgets('横書き設定でNovelContentViewがレンダリングされること', (tester) async {
+    await pumpWidget(
+      tester,
+      contentValue: AsyncData(testContent),
+      settingsValue: AsyncData(defaultTestSettings.copyWith(isVertical: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NovelContentView), findsOneWidget);
+  });
+
+  testWidgets('ウィジェット破棄時にUIモードがリセットされること', (tester) async {
+    await pumpWidget(
+      tester,
+      contentValue: AsyncData(testContent),
+      settingsValue: AsyncData(defaultTestSettings.copyWith(isVertical: true)),
+    );
+    await tester.pumpAndSettle();
+
+    // ウィジェットを破棄
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 破棄後もエラーが発生しないことを確認
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION
## 概要
縦書き表示時のエピソードスクロールとシステムホームジェスチャーが干渉する問題を解決するため、`immersiveSticky`モードを導入しました。

## 変更内容
- 縦書き表示時: `SystemUiMode.immersiveSticky` を設定
  - ホームジェスチャー（画面端スワイプ）が2回必要になり、誤操作を防止
- 横書き表示時: `SystemUiMode.edgeToEdge` を設定
  - 通常のシステムUI表示を維持
- ウィジェット破棄時: UIモードをリセット

## 技術的詳細
- `flutter/services.dart` の `SystemChrome` を使用
- `useEffect` フックで設定を管理し、ライフサイクルに応じて適切にクリーンアップ
- 設定変更は非同期で行い、Futureを適切にawait

## テスト
- 縦書き設定時の動作確認テストを追加
- 横書き設定時の動作確認テストを追加
- ウィジェット破棄時のクリーンアップテストを追加
- 全8件のテストがパス

## 注意事項
Android 15+ の Predictive Back Gesture との互換性については、最小限の実装として現状は考慮していません。問題が発生した場合は別途対応が必要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 垂直表示モードでの没入型（システムUI自動非表示）表示を追加しました。

* **改善**
  * 表示モード切替時に適切なシステムUIモードを設定する挙動を追加・調整しました。
  * ウィジェット破棄時にシステムUIモードを元に戻す安全なクリーンアップ処理を導入しました。

* **テスト**
  * 垂直／横向き表示と、破棄時のUI状態リセットが例外なしに動作することを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->