### PR TITLE
fix(db): v0.21.0→v0.22.0 DBマイグレーション失敗の修復とリカバリーUI

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -15,6 +15,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 export 'database_providers.dart';
+export 'migration_helper.dart';
 
 part 'database.g.dart';
 
@@ -364,141 +365,203 @@ class AppDatabase extends _$AppDatabase {
         await _createFtsTables();
       },
       onUpgrade: (m, from, to) async {
-        await m.runInTransaction(() async {
-          if (from < 12) {
-            // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
-            // 既存テーブルを削除してから新しいテーブルを作成する。
-            await customStatement('DROP TABLE IF EXISTS episodes');
-            await customStatement('DROP TABLE IF EXISTS library_entries');
-            await customStatement('DROP TABLE IF EXISTS reading_history');
-
-            // 1. 新規テーブルを作成する
-            await m.createTableIfNotExists(novels);
-            await m.createTableIfNotExists(libraryEntries);
-            await m.createTableIfNotExists(readingHistory);
-            // 旧episodesテーブル(v12〜v15で使用)を作成する
-            // v16マイグレーションで目次・本文テーブルへ分割される
-            await customStatement('''
-                CREATE TABLE IF NOT EXISTS episodes (
-                  ncode TEXT NOT NULL REFERENCES novels(ncode),
-                  episode_id INTEGER NOT NULL,
-                  subtitle TEXT,
-                  url TEXT,
-                  published_at TEXT,
-                  revised_at TEXT,
-                  content TEXT,
-                  fetched_at INTEGER,
-                  PRIMARY KEY (ncode, episode_id)
-                );
-              ''');
-
-            // 2. LibraryNovels から LibraryEntries と Novels へ移行
-            await customStatement('''
-                INSERT OR IGNORE INTO novels (
-                  ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-                )
-                SELECT 
-                  ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-                FROM library_novels;
-              ''');
-
-            await customStatement('''
-                INSERT OR IGNORE INTO library_entries (ncode, added_at)
-                SELECT ncode, added_at FROM library_novels;
-              ''');
-
-            // 3. History から ReadingHistory と Novels へ移行
-            await customStatement('''
-                INSERT OR IGNORE INTO novels (ncode, cached_at)
-                SELECT ncode, viewed_at FROM history;
-              ''');
-
-            await customStatement('''
-                INSERT OR IGNORE INTO reading_history
-                  (ncode, last_episode_id, viewed_at, updated_at)
-                SELECT ncode, last_episode, viewed_at, updated_at FROM history;
-              ''');
-
-            // 4. CachedEpisodes から Episodes へ移行
-
-            // 古いキャッシュエピソードテーブルが存在するか確認する
-            final cachedEpisodesResult = await customSelect(
-              'SELECT name FROM sqlite_master '
-              "WHERE type='table' AND name='cached_episodes'",
-            ).get();
-
-            if (cachedEpisodesResult.isNotEmpty) {
-              await customStatement('''
-                  INSERT OR IGNORE INTO episodes
-                    (ncode, episode_id, content, fetched_at, revised_at)
-                  SELECT ncode, episode, content, cached_at, revised FROM cached_episodes;
-                ''');
-            }
-
-            // 5. 旧テーブルを削除する
-            await customStatement('DROP TABLE IF EXISTS library_novels');
-            await customStatement('DROP TABLE IF EXISTS history');
-            await customStatement('DROP TABLE IF EXISTS cached_episodes');
-          }
-
-          if (from < 13) {
-            // Version 13 migration (Triggers based FTS)
-            // - skipped or overwritten by 14
-          }
-
-          if (from < 16) {
-            // 旧episodesテーブルを目次・本文の2テーブルに分割する
-            // v14のFTS再構築より前に実行し、_populateFtsTables()で
-            // episode_list_entries / episode_contents を参照できるようにする
-            await m.createTableIfNotExists(episodeListEntries);
-            await m.createTableIfNotExists(episodeContents);
-
-            // episodes テーブルが存在する場合のみデータを引き継ぐ
-            // （マイグレーション中断により episodes が既に削除されている可能性もあるため）
-            if (await m.tableExists('episodes')) {
-              // 目次データの引き継ぎ(目次の取得日時は旧スキーマに存在しないためNULL)
-              await customStatement('''
-                  INSERT OR IGNORE INTO episode_list_entries
-                    (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
-                  SELECT ncode, episode_id, subtitle, url, published_at, revised_at, NULL
-                  FROM episodes;
-                ''');
-
-              // 本文データの引き継ぎ(content IS NOT NULL の行のみ)
-              await customStatement('''
-                  INSERT OR IGNORE INTO episode_contents
-                    (ncode, episode_id, content, fetched_at, revised_at)
-                  SELECT ncode, episode_id, content, fetched_at, revised_at
-                  FROM episodes
-                  WHERE content IS NOT NULL;
-                ''');
-
+        try {
+          await m.runInTransaction(() async {
+            if (from < 12) {
+              // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
+              // 既存テーブルを削除してから新しいテーブルを作成する。
               await customStatement('DROP TABLE IF EXISTS episodes');
+              await customStatement('DROP TABLE IF EXISTS library_entries');
+              await customStatement('DROP TABLE IF EXISTS reading_history');
+
+              // 1. 新規テーブルを作成する
+              await m.createTableIfNotExists(novels);
+              await m.createTableIfNotExists(libraryEntries);
+              await m.createTableIfNotExists(readingHistory);
+              // 旧episodesテーブル(v12〜v15で使用)を作成する
+              // v16マイグレーションで目次・本文テーブルへ分割される
+              await customStatement('''
+                  CREATE TABLE IF NOT EXISTS episodes (
+                    ncode TEXT NOT NULL REFERENCES novels(ncode),
+                    episode_id INTEGER NOT NULL,
+                    subtitle TEXT,
+                    url TEXT,
+                    published_at TEXT,
+                    revised_at TEXT,
+                    content TEXT,
+                    fetched_at INTEGER,
+                    PRIMARY KEY (ncode, episode_id)
+                  );
+                ''');
+
+              // 2. LibraryNovels から LibraryEntries と Novels へ移行
+              await customStatement('''
+                  INSERT OR IGNORE INTO novels (
+                    ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                  )
+                  SELECT 
+                    ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                  FROM library_novels;
+                ''');
+
+              await customStatement('''
+                  INSERT OR IGNORE INTO library_entries (ncode, added_at)
+                  SELECT ncode, added_at FROM library_novels;
+                ''');
+
+              // 3. History から ReadingHistory と Novels へ移行
+              await customStatement('''
+                  INSERT OR IGNORE INTO novels (ncode, cached_at)
+                  SELECT ncode, viewed_at FROM history;
+                ''');
+
+              await customStatement('''
+                  INSERT OR IGNORE INTO reading_history
+                    (ncode, last_episode_id, viewed_at, updated_at)
+                  SELECT ncode, last_episode, viewed_at, updated_at FROM history;
+                ''');
+
+              // 4. CachedEpisodes から Episodes へ移行
+
+              // 古いキャッシュエピソードテーブルが存在するか確認する
+              final cachedEpisodesResult = await customSelect(
+                'SELECT name FROM sqlite_master '
+                "WHERE type='table' AND name='cached_episodes'",
+              ).get();
+
+              if (cachedEpisodesResult.isNotEmpty) {
+                await customStatement('''
+                    INSERT OR IGNORE INTO episodes
+                      (ncode, episode_id, content, fetched_at, revised_at)
+                    SELECT ncode, episode, content, cached_at, revised FROM cached_episodes;
+                  ''');
+              }
+
+              // 5. 旧テーブルを削除する
+              await customStatement('DROP TABLE IF EXISTS library_novels');
+              await customStatement('DROP TABLE IF EXISTS history');
+              await customStatement('DROP TABLE IF EXISTS cached_episodes');
             }
 
-            // 非公開フラグカラムの追加
-            // (v12未満からのマイグレーションではNovelsが新スキーマで作成済みのため不要)
-            if (from >= 12) {
-              await m.addColumnIfNotExists(novels, novels.isPrivate);
+            if (from < 13) {
+              // Version 13 migration (Triggers based FTS)
+              // - skipped or overwritten by 14
             }
-          }
 
-          if (from >= 12 && from < 15) {
-            await m.addColumnIfNotExists(novels, novels.userId);
-          }
+            if (from < 16) {
+              // 旧episodesテーブルを目次・本文の2テーブルに分割する
+              // v14のFTS再構築より前に実行し、_populateFtsTables()で
+              // episode_list_entries / episode_contents を参照できるようにする
+              await m.createTableIfNotExists(episodeListEntries);
+              await m.createTableIfNotExists(episodeContents);
 
-          if (from < 14) {
-            // トリグラムトークナイザーからデフォルトトークナイザー(simple)へ切り替え、
-            // トリガーを削除したためFTSテーブルを手動で再構築・再投入する
-            await customStatement('DROP TABLE IF EXISTS novels_search');
-            await customStatement('DROP TABLE IF EXISTS episodes_search');
+              // episodes テーブルが存在する場合のみデータを引き継ぐ
+              // （マイグレーション中断により episodes が既に削除されている可能性もあるため）
+              if (await m.tableExists('episodes')) {
+                // 目次データの引き継ぎ(目次の取得日時は旧スキーマに存在しないためNULL)
+                await customStatement('''
+                    INSERT OR IGNORE INTO episode_list_entries
+                      (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
+                    SELECT ncode, episode_id, subtitle, url, published_at, revised_at, NULL
+                    FROM episodes;
+                  ''');
 
-            await _createFtsTables();
-            await _populateFtsTables();
-          }
-        });
+                // 本文データの引き継ぎ(content IS NOT NULL の行のみ)
+                await customStatement('''
+                    INSERT OR IGNORE INTO episode_contents
+                      (ncode, episode_id, content, fetched_at, revised_at)
+                    SELECT ncode, episode_id, content, fetched_at, revised_at
+                    FROM episodes
+                    WHERE content IS NOT NULL;
+                  ''');
+
+                await customStatement('DROP TABLE IF EXISTS episodes');
+              }
+
+              // 非公開フラグカラムの追加
+              // (v12未満からのマイグレーションではNovelsが新スキーマで作成済みのため不要)
+              if (from >= 12) {
+                await m.addColumnIfNotExists(novels, novels.isPrivate);
+              }
+            }
+
+            if (from >= 12 && from < 15) {
+              await m.addColumnIfNotExists(novels, novels.userId);
+            }
+
+            if (from < 14) {
+              // トリグラムトークナイザーからデフォルトトークナイザー(simple)へ切り替え、
+              // トリガーを削除したためFTSテーブルを手動で再構築・再投入する
+              await customStatement('DROP TABLE IF EXISTS novels_search');
+              await customStatement('DROP TABLE IF EXISTS episodes_search');
+
+              await _createFtsTables();
+              await _populateFtsTables();
+            }
+          });
+        } on MigrationException {
+          rethrow;
+        } on Object catch (e, s) {
+          await _saveMigrationErrorReport(from, to, e, s);
+          throw MigrationException(
+            fromVersion: from,
+            toVersion: to,
+            step: 'onUpgrade',
+            cause: e,
+            stackTrace: s,
+          );
+        }
+
+        await _clearMigrationErrorReports();
       },
     );
+  }
+
+  Future<void> _saveMigrationErrorReport(
+    int? fromVersion,
+    int toVersion,
+    Object error,
+    StackTrace stackTrace,
+  ) async {
+    try {
+      final dbFilePath = await _databaseFilePath();
+      final report = MigrationErrorReport(
+        formatVersion: 1,
+        timestamp: DateTime.now().toIso8601String(),
+        schemaVersionBefore: fromVersion,
+        schemaVersionAfter: toVersion,
+        failedStep: 'onUpgrade',
+        errorMessage: error.toString(),
+        stackTrace: stackTrace.toString(),
+        dbFilePath: dbFilePath,
+      );
+      await saveMigrationErrorReport(report);
+    } on Exception catch (e) {
+      // レポート保存自体の失敗は無視する（マイグレーション失敗より重要ではない）
+      debugPrint('マイグレーションエラーレポートの保存に失敗しました: $e');
+    }
+  }
+
+  Future<String?> _databaseFilePath() async {
+    try {
+      final rows = await customSelect('PRAGMA database_list').get();
+      for (final row in rows) {
+        if (row.read<int>('seq') == 0) {
+          return row.read<String?>('file');
+        }
+      }
+      return null;
+    } on Exception {
+      return null;
+    }
+  }
+
+  Future<void> _clearMigrationErrorReports() async {
+    try {
+      await clearMigrationErrorReports();
+    } on Exception catch (e) {
+      debugPrint('マイグレーションエラーレポートの削除に失敗しました: $e');
+    }
   }
 
   Future<void> _createFtsTables() async {

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -519,11 +519,6 @@ class AppDatabase extends _$AppDatabase {
                         SELECT revised_at FROM episodes
                         WHERE episodes.ncode = episode_list_entries.ncode
                           AND episodes.episode_id = episode_list_entries.episode_id
-                      ),
-                      fetched_at = (
-                        SELECT fetched_at FROM episodes
-                        WHERE episodes.ncode = episode_list_entries.ncode
-                          AND episodes.episode_id = episode_list_entries.episode_id
                       )
                     WHERE EXISTS (
                       SELECT 1 FROM episodes

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -100,7 +100,10 @@ class HistoryData {
 
   @override
   String toString() {
-    return 'HistoryData(ncode: $ncode, title: $title, writer: $writer, lastEpisode: $lastEpisode, viewedAt: $viewedAt, updatedAt: $updatedAt)';
+    return 'HistoryData('
+        'ncode: $ncode, title: $title, writer: $writer, '
+        'lastEpisode: $lastEpisode, viewedAt: $viewedAt, '
+        'updatedAt: $updatedAt)';
   }
 }
 
@@ -1419,4 +1422,4 @@ LazyDatabase _openConnection() {
   });
 }
 
-// ==================== Providers Moved to database_providers.dart ====================
+// === Providers moved to database_providers.dart ===

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -375,12 +375,9 @@ class AppDatabase extends _$AppDatabase {
           await m.runInTransaction(() async {
             if (from < 12) {
               // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
-              // 既存テーブルを削除してから新しいテーブルを作成する。
-              await customStatement('DROP TABLE IF EXISTS episodes');
-              await customStatement('DROP TABLE IF EXISTS library_entries');
-              await customStatement('DROP TABLE IF EXISTS reading_history');
+              // 既存の新規テーブルはそのまま残し、不足データを補填する形で移行する。
 
-              // 1. 新規テーブルを作成する
+              // 1. 新規テーブルが存在しない場合のみ作成する
               await m.createTable(novels);
               await m.createTable(libraryEntries);
               await m.createTable(readingHistory);
@@ -400,34 +397,63 @@ class AppDatabase extends _$AppDatabase {
                   );
                 ''');
 
-              // 2. LibraryNovels から LibraryEntries と Novels へ移行
-              await customStatement('''
-                  INSERT OR IGNORE INTO novels (
-                    ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-                  )
-                  SELECT 
-                    ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-                  FROM library_novels;
-                ''');
+              // 2. library_novels から library_entries と novels へ移行
+              final libraryNovelsResult = await customSelect(
+                '''
+                SELECT name FROM sqlite_master
+                WHERE type='table' AND name='library_novels'
+                ''',
+              ).get();
+              if (libraryNovelsResult.isNotEmpty) {
+                await customStatement('''
+                    INSERT OR IGNORE INTO novels (
+                      ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                    )
+                    SELECT
+                      ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                    FROM library_novels;
+                  ''');
 
-              await customStatement('''
-                  INSERT OR IGNORE INTO library_entries (ncode, added_at)
-                  SELECT ncode, added_at FROM library_novels;
-                ''');
+                await customStatement('''
+                    INSERT OR IGNORE INTO library_entries (ncode, added_at)
+                    SELECT ncode, added_at FROM library_novels;
+                  ''');
+              }
 
-              // 3. History から ReadingHistory と Novels へ移行
-              await customStatement('''
-                  INSERT OR IGNORE INTO novels (ncode, cached_at)
-                  SELECT ncode, viewed_at FROM history;
-                ''');
+              // 3. history から reading_history と novels へ移行
+              final historyResult = await customSelect(
+                '''
+                SELECT name FROM sqlite_master
+                WHERE type='table' AND name='history'
+                ''',
+              ).get();
+              if (historyResult.isNotEmpty) {
+                await customStatement('''
+                    INSERT OR IGNORE INTO novels (ncode, cached_at)
+                    SELECT ncode, viewed_at FROM history
+                    WHERE viewed_at IS NOT NULL;
+                  ''');
 
-              await customStatement('''
-                  INSERT OR IGNORE INTO reading_history
-                    (ncode, last_episode_id, viewed_at, updated_at)
-                  SELECT ncode, last_episode, viewed_at, updated_at FROM history;
-                ''');
+                await customStatement('''
+                    UPDATE novels
+                    SET cached_at = (
+                      SELECT viewed_at FROM history
+                      WHERE history.ncode = novels.ncode
+                    )
+                    WHERE EXISTS (
+                      SELECT 1 FROM history
+                      WHERE history.ncode = novels.ncode
+                    );
+                  ''');
 
-              // 4. CachedEpisodes から Episodes へ移行
+                await customStatement('''
+                    INSERT OR IGNORE INTO reading_history
+                      (ncode, last_episode_id, viewed_at, updated_at)
+                    SELECT ncode, last_episode, viewed_at, updated_at FROM history;
+                  ''');
+              }
+
+              // 4. cached_episodes から episodes へ移行
 
               // 古いキャッシュエピソードテーブルが存在するか確認する
               final cachedEpisodesResult = await customSelect(
@@ -450,8 +476,8 @@ class AppDatabase extends _$AppDatabase {
             }
 
             if (from < 13) {
-              // Version 13 migration (Triggers based FTS)
-              // - skipped or overwritten by 14
+              // バージョン13のマイグレーション（トリガー方式のFTS）
+              // - バージョン14で上書きされるためスキップ
             }
 
             if (from < 16) {
@@ -465,6 +491,7 @@ class AppDatabase extends _$AppDatabase {
               // （マイグレーション中断により episodes が既に削除されている可能性もあるため）
               if (await m.tableExists('episodes')) {
                 // 目次データの引き継ぎ(目次の取得日時は旧スキーマに存在しないためNULL)
+                // 競合時は episodes 側の完全な値で上書きする
                 await customStatement('''
                     INSERT OR IGNORE INTO episode_list_entries
                       (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
@@ -472,13 +499,72 @@ class AppDatabase extends _$AppDatabase {
                     FROM episodes;
                   ''');
 
+                await customStatement('''
+                    UPDATE episode_list_entries
+                    SET subtitle = (
+                        SELECT subtitle FROM episodes
+                        WHERE episodes.ncode = episode_list_entries.ncode
+                          AND episodes.episode_id = episode_list_entries.episode_id
+                      ),
+                      url = (
+                        SELECT url FROM episodes
+                        WHERE episodes.ncode = episode_list_entries.ncode
+                          AND episodes.episode_id = episode_list_entries.episode_id
+                      ),
+                      published_at = (
+                        SELECT published_at FROM episodes
+                        WHERE episodes.ncode = episode_list_entries.ncode
+                          AND episodes.episode_id = episode_list_entries.episode_id
+                      ),
+                      revised_at = (
+                        SELECT revised_at FROM episodes
+                        WHERE episodes.ncode = episode_list_entries.ncode
+                          AND episodes.episode_id = episode_list_entries.episode_id
+                      ),
+                      fetched_at = (
+                        SELECT fetched_at FROM episodes
+                        WHERE episodes.ncode = episode_list_entries.ncode
+                          AND episodes.episode_id = episode_list_entries.episode_id
+                      )
+                    WHERE EXISTS (
+                      SELECT 1 FROM episodes
+                      WHERE episodes.ncode = episode_list_entries.ncode
+                        AND episodes.episode_id = episode_list_entries.episode_id
+                    );
+                  ''');
+
                 // 本文データの引き継ぎ(content IS NOT NULL の行のみ)
+                // 競合時は episodes 側の完全な値で上書きする
                 await customStatement('''
                     INSERT OR IGNORE INTO episode_contents
                       (ncode, episode_id, content, fetched_at, revised_at)
                     SELECT ncode, episode_id, content, fetched_at, revised_at
                     FROM episodes
                     WHERE content IS NOT NULL;
+                  ''');
+
+                await customStatement('''
+                    UPDATE episode_contents
+                    SET content = (
+                        SELECT content FROM episodes
+                        WHERE episodes.ncode = episode_contents.ncode
+                          AND episodes.episode_id = episode_contents.episode_id
+                      ),
+                      fetched_at = (
+                        SELECT fetched_at FROM episodes
+                        WHERE episodes.ncode = episode_contents.ncode
+                          AND episodes.episode_id = episode_contents.episode_id
+                      ),
+                      revised_at = (
+                        SELECT revised_at FROM episodes
+                        WHERE episodes.ncode = episode_contents.ncode
+                          AND episodes.episode_id = episode_contents.episode_id
+                      )
+                    WHERE EXISTS (
+                      SELECT 1 FROM episodes
+                      WHERE episodes.ncode = episode_contents.ncode
+                        AND episodes.episode_id = episode_contents.episode_id
+                    );
                   ''');
 
                 await customStatement('DROP TABLE IF EXISTS episodes');

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -372,8 +372,7 @@ class AppDatabase extends _$AppDatabase {
       },
       onUpgrade: (m, from, to) async {
         try {
-          await m.runInTransaction(() async {
-            if (from < 12) {
+          if (from < 12) {
               // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
               // 既存の新規テーブルはそのまま残し、不足データを補填する形で移行する。
 
@@ -590,7 +589,6 @@ class AppDatabase extends _$AppDatabase {
               await _createFtsTables();
               await _populateFtsTables();
             }
-          });
         } on MigrationException {
           rethrow;
         } on Object catch (e) {

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -6,6 +6,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart';
 import 'package:narou_parser/narou_parser.dart';
+import 'package:novelty/database/migration_helper.dart';
 import 'package:novelty/models/episode.dart';
 import 'package:novelty/models/novel_download_summary.dart';
 import 'package:novelty/utils/ncode_utils.dart';
@@ -363,131 +364,139 @@ class AppDatabase extends _$AppDatabase {
         await _createFtsTables();
       },
       onUpgrade: (m, from, to) async {
-        if (from < 12) {
-          // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
-          // 既存テーブルを削除してから新しいテーブルを作成する。
-          await customStatement('DROP TABLE IF EXISTS episodes');
-          await customStatement('DROP TABLE IF EXISTS library_entries');
-          await customStatement('DROP TABLE IF EXISTS reading_history');
+        await m.runInTransaction(() async {
+          if (from < 12) {
+            // 以前のマイグレーション失敗などでテーブルが中途半端に存在する可能性があるため、
+            // 既存テーブルを削除してから新しいテーブルを作成する。
+            await customStatement('DROP TABLE IF EXISTS episodes');
+            await customStatement('DROP TABLE IF EXISTS library_entries');
+            await customStatement('DROP TABLE IF EXISTS reading_history');
 
-          // 1. 新規テーブルを作成する
-          await m.createTable(novels);
-          await m.createTable(libraryEntries);
-          await m.createTable(readingHistory);
-          // 旧episodesテーブル(v12〜v15で使用)を作成する
-          // v16マイグレーションで目次・本文テーブルへ分割される
-          await customStatement('''
-              CREATE TABLE episodes (
-                ncode TEXT NOT NULL REFERENCES novels(ncode),
-                episode_id INTEGER NOT NULL,
-                subtitle TEXT,
-                url TEXT,
-                published_at TEXT,
-                revised_at TEXT,
-                content TEXT,
-                fetched_at INTEGER,
-                PRIMARY KEY (ncode, episode_id)
-              );
-            ''');
-
-          // 2. LibraryNovels から LibraryEntries と Novels へ移行
-          await customStatement('''
-              INSERT OR IGNORE INTO novels (
-                ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-              )
-              SELECT 
-                ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
-              FROM library_novels;
-            ''');
-
-          await customStatement('''
-              INSERT OR IGNORE INTO library_entries (ncode, added_at)
-              SELECT ncode, added_at FROM library_novels;
-            ''');
-
-          // 3. History から ReadingHistory と Novels へ移行
-          await customStatement('''
-              INSERT OR IGNORE INTO novels (ncode, cached_at)
-              SELECT ncode, viewed_at FROM history;
-            ''');
-
-          await customStatement('''
-              INSERT INTO reading_history (ncode, last_episode_id, viewed_at, updated_at)
-              SELECT ncode, last_episode, viewed_at, updated_at FROM history;
-            ''');
-
-          // 4. CachedEpisodes から Episodes へ移行
-
-          // 古いキャッシュエピソードテーブルが存在するか確認する
-          final cachedEpisodesResult = await customSelect(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='cached_episodes'",
-          ).get();
-
-          if (cachedEpisodesResult.isNotEmpty) {
+            // 1. 新規テーブルを作成する
+            await m.createTableIfNotExists(novels);
+            await m.createTableIfNotExists(libraryEntries);
+            await m.createTableIfNotExists(readingHistory);
+            // 旧episodesテーブル(v12〜v15で使用)を作成する
+            // v16マイグレーションで目次・本文テーブルへ分割される
             await customStatement('''
-                INSERT INTO episodes (ncode, episode_id, content, fetched_at, revised_at)
-                SELECT ncode, episode, content, cached_at, revised FROM cached_episodes;
+                CREATE TABLE IF NOT EXISTS episodes (
+                  ncode TEXT NOT NULL REFERENCES novels(ncode),
+                  episode_id INTEGER NOT NULL,
+                  subtitle TEXT,
+                  url TEXT,
+                  published_at TEXT,
+                  revised_at TEXT,
+                  content TEXT,
+                  fetched_at INTEGER,
+                  PRIMARY KEY (ncode, episode_id)
+                );
               ''');
+
+            // 2. LibraryNovels から LibraryEntries と Novels へ移行
+            await customStatement('''
+                INSERT OR IGNORE INTO novels (
+                  ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                )
+                SELECT 
+                  ncode, title, writer, story, novel_type, "end", general_all_no, novel_updated_at
+                FROM library_novels;
+              ''');
+
+            await customStatement('''
+                INSERT OR IGNORE INTO library_entries (ncode, added_at)
+                SELECT ncode, added_at FROM library_novels;
+              ''');
+
+            // 3. History から ReadingHistory と Novels へ移行
+            await customStatement('''
+                INSERT OR IGNORE INTO novels (ncode, cached_at)
+                SELECT ncode, viewed_at FROM history;
+              ''');
+
+            await customStatement('''
+                INSERT OR IGNORE INTO reading_history
+                  (ncode, last_episode_id, viewed_at, updated_at)
+                SELECT ncode, last_episode, viewed_at, updated_at FROM history;
+              ''');
+
+            // 4. CachedEpisodes から Episodes へ移行
+
+            // 古いキャッシュエピソードテーブルが存在するか確認する
+            final cachedEpisodesResult = await customSelect(
+              'SELECT name FROM sqlite_master '
+              "WHERE type='table' AND name='cached_episodes'",
+            ).get();
+
+            if (cachedEpisodesResult.isNotEmpty) {
+              await customStatement('''
+                  INSERT OR IGNORE INTO episodes
+                    (ncode, episode_id, content, fetched_at, revised_at)
+                  SELECT ncode, episode, content, cached_at, revised FROM cached_episodes;
+                ''');
+            }
+
+            // 5. 旧テーブルを削除する
+            await customStatement('DROP TABLE IF EXISTS library_novels');
+            await customStatement('DROP TABLE IF EXISTS history');
+            await customStatement('DROP TABLE IF EXISTS cached_episodes');
           }
 
-          // 5. 旧テーブルを削除する
-          await customStatement('DROP TABLE IF EXISTS library_novels');
-          await customStatement('DROP TABLE IF EXISTS history');
-          await customStatement('DROP TABLE IF EXISTS cached_episodes');
-        }
-
-        if (from < 13) {
-          // Version 13 migration (Triggers based FTS) - skipped or overwritten by 14
-        }
-
-        if (from < 16) {
-          // 旧episodesテーブルを目次・本文の2テーブルに分割する
-          // v14のFTS再構築より前に実行し、_populateFtsTables()で
-          // episode_list_entries / episode_contents を参照できるようにする
-          await m.createTable(episodeListEntries);
-          await m.createTable(episodeContents);
-
-          // 目次データの引き継ぎ(目次の取得日時は旧スキーマに存在しないためNULL)
-          await customStatement('''
-              INSERT INTO episode_list_entries
-                (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
-              SELECT ncode, episode_id, subtitle, url, published_at, revised_at, NULL
-              FROM episodes;
-            ''');
-
-          // 本文データの引き継ぎ(content IS NOT NULL の行のみ)
-          await customStatement('''
-              INSERT INTO episode_contents
-                (ncode, episode_id, content, fetched_at, revised_at)
-              SELECT ncode, episode_id, content, fetched_at, revised_at
-              FROM episodes
-              WHERE content IS NOT NULL;
-            ''');
-
-          await customStatement('DROP TABLE episodes');
-
-          // 非公開フラグカラムの追加
-          // (v12未満からのマイグレーションではNovelsが新スキーマで作成済みのため不要)
-          if (from >= 12) {
-            await m.addColumn(novels, novels.isPrivate);
+          if (from < 13) {
+            // Version 13 migration (Triggers based FTS)
+            // - skipped or overwritten by 14
           }
-        }
 
-        if (from >= 12 && from < 15) {
-          await customStatement(
-            'ALTER TABLE novels ADD COLUMN user_id INTEGER',
-          );
-        }
+          if (from < 16) {
+            // 旧episodesテーブルを目次・本文の2テーブルに分割する
+            // v14のFTS再構築より前に実行し、_populateFtsTables()で
+            // episode_list_entries / episode_contents を参照できるようにする
+            await m.createTableIfNotExists(episodeListEntries);
+            await m.createTableIfNotExists(episodeContents);
 
-        if (from < 14) {
-          // トリグラムトークナイザーからデフォルトトークナイザー(simple)へ切り替え、
-          // トリガーを削除したためFTSテーブルを手動で再構築・再投入する
-          await customStatement('DROP TABLE IF EXISTS novels_search');
-          await customStatement('DROP TABLE IF EXISTS episodes_search');
+            // episodes テーブルが存在する場合のみデータを引き継ぐ
+            // （マイグレーション中断により episodes が既に削除されている可能性もあるため）
+            if (await m.tableExists('episodes')) {
+              // 目次データの引き継ぎ(目次の取得日時は旧スキーマに存在しないためNULL)
+              await customStatement('''
+                  INSERT OR IGNORE INTO episode_list_entries
+                    (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
+                  SELECT ncode, episode_id, subtitle, url, published_at, revised_at, NULL
+                  FROM episodes;
+                ''');
 
-          await _createFtsTables();
-          await _populateFtsTables();
-        }
+              // 本文データの引き継ぎ(content IS NOT NULL の行のみ)
+              await customStatement('''
+                  INSERT OR IGNORE INTO episode_contents
+                    (ncode, episode_id, content, fetched_at, revised_at)
+                  SELECT ncode, episode_id, content, fetched_at, revised_at
+                  FROM episodes
+                  WHERE content IS NOT NULL;
+                ''');
+
+              await customStatement('DROP TABLE IF EXISTS episodes');
+            }
+
+            // 非公開フラグカラムの追加
+            // (v12未満からのマイグレーションではNovelsが新スキーマで作成済みのため不要)
+            if (from >= 12) {
+              await m.addColumnIfNotExists(novels, novels.isPrivate);
+            }
+          }
+
+          if (from >= 12 && from < 15) {
+            await m.addColumnIfNotExists(novels, novels.userId);
+          }
+
+          if (from < 14) {
+            // トリグラムトークナイザーからデフォルトトークナイザー(simple)へ切り替え、
+            // トリガーを削除したためFTSテーブルを手動で再構築・再投入する
+            await customStatement('DROP TABLE IF EXISTS novels_search');
+            await customStatement('DROP TABLE IF EXISTS episodes_search');
+
+            await _createFtsTables();
+            await _populateFtsTables();
+          }
+        });
       },
     );
   }

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -381,9 +381,9 @@ class AppDatabase extends _$AppDatabase {
               await customStatement('DROP TABLE IF EXISTS reading_history');
 
               // 1. 新規テーブルを作成する
-              await m.createTableIfNotExists(novels);
-              await m.createTableIfNotExists(libraryEntries);
-              await m.createTableIfNotExists(readingHistory);
+              await m.createTable(novels);
+              await m.createTable(libraryEntries);
+              await m.createTable(readingHistory);
               // 旧episodesテーブル(v12〜v15で使用)を作成する
               // v16マイグレーションで目次・本文テーブルへ分割される
               await customStatement('''
@@ -458,8 +458,8 @@ class AppDatabase extends _$AppDatabase {
               // 旧episodesテーブルを目次・本文の2テーブルに分割する
               // v14のFTS再構築より前に実行し、_populateFtsTables()で
               // episode_list_entries / episode_contents を参照できるようにする
-              await m.createTableIfNotExists(episodeListEntries);
-              await m.createTableIfNotExists(episodeContents);
+              await m.createTable(episodeListEntries);
+              await m.createTable(episodeContents);
 
               // episodes テーブルが存在する場合のみデータを引き継ぐ
               // （マイグレーション中断により episodes が既に削除されている可能性もあるため）
@@ -507,15 +507,15 @@ class AppDatabase extends _$AppDatabase {
           });
         } on MigrationException {
           rethrow;
-        } on Object catch (e, s) {
-          await _saveMigrationErrorReport(from, to, e, s);
-          throw MigrationException(
+        } on Object catch (e) {
+          final exception = MigrationException(
             fromVersion: from,
             toVersion: to,
             step: 'onUpgrade',
             cause: e,
-            stackTrace: s,
           );
+          await _saveMigrationErrorReport(exception);
+          throw exception;
         }
 
         await _clearMigrationErrorReports();
@@ -523,22 +523,11 @@ class AppDatabase extends _$AppDatabase {
     );
   }
 
-  Future<void> _saveMigrationErrorReport(
-    int? fromVersion,
-    int toVersion,
-    Object error,
-    StackTrace stackTrace,
-  ) async {
+  Future<void> _saveMigrationErrorReport(MigrationException exception) async {
     try {
       final dbFilePath = await _databaseFilePath();
-      final report = MigrationErrorReport(
-        formatVersion: 1,
-        timestamp: DateTime.now().toIso8601String(),
-        schemaVersionBefore: fromVersion,
-        schemaVersionAfter: toVersion,
-        failedStep: 'onUpgrade',
-        errorMessage: error.toString(),
-        stackTrace: stackTrace.toString(),
+      final report = MigrationErrorReport.fromException(
+        exception,
         dbFilePath: dbFilePath,
       );
       await saveMigrationErrorReport(report);

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -354,8 +354,11 @@ class AppDatabase extends _$AppDatabase {
   /// テスト用コンストラクタ（任意のQueryExecutorを指定する）
   AppDatabase.test(super.e);
 
+  /// 現在のデータベーススキーマバージョン
+  static const int currentSchemaVersion = 16;
+
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => currentSchemaVersion;
 
   @override
   MigrationStrategy get migration {

--- a/lib/database/migration_helper.dart
+++ b/lib/database/migration_helper.dart
@@ -49,6 +49,7 @@ class MigrationErrorReport {
   });
 
   /// 例外からレポートを生成する。
+  /// dbFilePath にはファイル名のみを保持し、絶対パスは記録しない。
   factory MigrationErrorReport.fromException(
     MigrationException exception, {
     String? dbFilePath,
@@ -60,7 +61,7 @@ class MigrationErrorReport {
       schemaVersionAfter: exception.toVersion,
       failedStep: exception.step,
       errorMessage: exception.cause.toString(),
-      dbFilePath: dbFilePath,
+      dbFilePath: dbFilePath != null ? p.basename(dbFilePath) : null,
     );
   }
 

--- a/lib/database/migration_helper.dart
+++ b/lib/database/migration_helper.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// マイグレーションに失敗した際に発生する例外。
+/// サポート用の情報（対象バージョン、失敗ステップ、元エラー）を保持する。
+class MigrationException implements Exception {
+  /// コンストラクタ
+  MigrationException({
+    required this.fromVersion,
+    required this.toVersion,
+    required this.step,
+    required this.cause,
+    this.stackTrace,
+  });
+
+  /// 移行前のスキーマバージョン
+  final int? fromVersion;
+
+  /// 移行後のスキーマバージョン
+  final int toVersion;
+
+  /// 失敗したマイグレーションステップの識別子
+  final String step;
+
+  /// 元のエラー
+  final Object cause;
+
+  /// スタックトレース
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() {
+    return 'MigrationException(from=$fromVersion, to=$toVersion, step=$step, '
+        'cause=$cause)';
+  }
+}
+
+/// マイグレーション失敗時のレポート情報を保持するモデル。
+class MigrationErrorReport {
+  /// コンストラクタ
+  const MigrationErrorReport({
+    required this.formatVersion,
+    required this.timestamp,
+    required this.schemaVersionBefore,
+    required this.schemaVersionAfter,
+    required this.failedStep,
+    required this.errorMessage,
+    this.stackTrace,
+    this.appVersion,
+    this.dbFilePath,
+  });
+
+  /// レポート形式のバージョン
+  final int formatVersion;
+
+  /// 発生時刻（ISO 8601）
+  final String timestamp;
+
+  /// 移行前のスキーマバージョン
+  final int? schemaVersionBefore;
+
+  /// 移行後のスキーマバージョン
+  final int schemaVersionAfter;
+
+  /// 失敗したステップ
+  final String failedStep;
+
+  /// エラーメッセージ
+  final String errorMessage;
+
+  /// スタックトレース（存在する場合）
+  final String? stackTrace;
+
+  /// アプリバージョン（存在する場合）
+  final String? appVersion;
+
+  /// DBファイルパス（存在する場合）
+  final String? dbFilePath;
+
+  /// JSON 形式のマップに変換する
+  Map<String, dynamic> toJson() => {
+        'formatVersion': formatVersion,
+        'timestamp': timestamp,
+        'schemaVersionBefore': schemaVersionBefore,
+        'schemaVersionAfter': schemaVersionAfter,
+        'failedStep': failedStep,
+        'errorMessage': errorMessage,
+        if (stackTrace != null) 'stackTrace': stackTrace,
+        if (appVersion != null) 'appVersion': appVersion,
+        if (dbFilePath != null) 'dbFilePath': dbFilePath,
+      };
+}
+
+/// [Migrator] に冪等・原子なマイグレーションを支援するための拡張メソッド。
+extension MigratorHelpers on Migrator {
+  /// 指定したアクションをトランザクション内で実行する。
+  /// マイグレーション内の全操作を原子化するために使用する。
+  Future<void> runInTransaction(Future<void> Function() action) async {
+    await database.transaction(action);
+  }
+
+  /// テーブルが存在しない場合のみ作成する。
+  /// Drift の [createTable] は内部で `CREATE TABLE IF NOT EXISTS` を発行するため、
+  /// そのまま委譲する。
+  Future<void> createTableIfNotExists<T extends Table, D extends DataClass>(
+    TableInfo<T, D> table,
+  ) async {
+    await createTable(table);
+  }
+
+  /// 指定したカラムが存在しない場合のみ追加する。
+  Future<void> addColumnIfNotExists<T extends Table, D extends DataClass>(
+    TableInfo<T, D> table,
+    GeneratedColumn<Object> column,
+  ) async {
+    final tableName = table.actualTableName;
+    final columnName = column.name;
+    final existingColumns = await database.customSelect(
+      'PRAGMA table_info($tableName)',
+    ).get();
+    final exists = existingColumns.any(
+      (row) => row.read<String>('name') == columnName,
+    );
+    if (!exists) {
+      await addColumn(table, column);
+    }
+  }
+
+  /// 指定したテーブルが存在するかどうかを確認する。
+  Future<bool> tableExists(String tableName) async {
+    final result = await database.customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      variables: [Variable.withString(tableName)],
+    ).get();
+    return result.isNotEmpty;
+  }
+}
+
+/// マイグレーション失敗時のレポートを保存する。
+/// アプリドキュメントディレクトリに JSON ファイルとして書き出す。
+Future<void> saveMigrationErrorReport(MigrationErrorReport report) async {
+  final docsDir = await getApplicationDocumentsDirectory();
+  final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-');
+  final file = File(
+    p.join(
+      docsDir.path,
+      'novelty_migration_error_report_$timestamp.json',
+    ),
+  );
+  await file.writeAsString(jsonEncode(report.toJson()));
+}
+
+/// 既存のマイグレーションエラーレポートファイルをすべて削除する。
+/// マイグレーション成功後に呼び出すことを想定している。
+Future<void> clearMigrationErrorReports() async {
+  final docsDir = await getApplicationDocumentsDirectory();
+  final files = docsDir
+      .listSync()
+      .whereType<File>()
+      .where(
+        (file) =>
+            p.basename(file.path).startsWith('novelty_migration_error_report_')
+            &&
+            p.basename(file.path).endsWith('.json'),
+      );
+  for (final file in files) {
+    await file.delete();
+  }
+}

--- a/lib/database/migration_helper.dart
+++ b/lib/database/migration_helper.dart
@@ -14,7 +14,6 @@ class MigrationException implements Exception {
     required this.toVersion,
     required this.step,
     required this.cause,
-    this.stackTrace,
   });
 
   /// 移行前のスキーマバージョン
@@ -28,9 +27,6 @@ class MigrationException implements Exception {
 
   /// 元のエラー
   final Object cause;
-
-  /// スタックトレース
-  final StackTrace? stackTrace;
 
   @override
   String toString() {
@@ -49,10 +45,24 @@ class MigrationErrorReport {
     required this.schemaVersionAfter,
     required this.failedStep,
     required this.errorMessage,
-    this.stackTrace,
-    this.appVersion,
     this.dbFilePath,
   });
+
+  /// 例外からレポートを生成する。
+  factory MigrationErrorReport.fromException(
+    MigrationException exception, {
+    String? dbFilePath,
+  }) {
+    return MigrationErrorReport(
+      formatVersion: 1,
+      timestamp: DateTime.now().toIso8601String(),
+      schemaVersionBefore: exception.fromVersion,
+      schemaVersionAfter: exception.toVersion,
+      failedStep: exception.step,
+      errorMessage: exception.cause.toString(),
+      dbFilePath: dbFilePath,
+    );
+  }
 
   /// レポート形式のバージョン
   final int formatVersion;
@@ -72,12 +82,6 @@ class MigrationErrorReport {
   /// エラーメッセージ
   final String errorMessage;
 
-  /// スタックトレース（存在する場合）
-  final String? stackTrace;
-
-  /// アプリバージョン（存在する場合）
-  final String? appVersion;
-
   /// DBファイルパス（存在する場合）
   final String? dbFilePath;
 
@@ -89,11 +93,12 @@ class MigrationErrorReport {
         'schemaVersionAfter': schemaVersionAfter,
         'failedStep': failedStep,
         'errorMessage': errorMessage,
-        if (stackTrace != null) 'stackTrace': stackTrace,
-        if (appVersion != null) 'appVersion': appVersion,
         if (dbFilePath != null) 'dbFilePath': dbFilePath,
       };
 }
+
+/// マイグレーションエラーレポートファイル名の接頭辞。
+const String _migrationReportFilePrefix = 'novelty_migration_error_report_';
 
 /// [Migrator] に冪等・原子なマイグレーションを支援するための拡張メソッド。
 extension MigratorHelpers on Migrator {
@@ -101,15 +106,6 @@ extension MigratorHelpers on Migrator {
   /// マイグレーション内の全操作を原子化するために使用する。
   Future<void> runInTransaction(Future<void> Function() action) async {
     await database.transaction(action);
-  }
-
-  /// テーブルが存在しない場合のみ作成する。
-  /// Drift の [createTable] は内部で `CREATE TABLE IF NOT EXISTS` を発行するため、
-  /// そのまま委譲する。
-  Future<void> createTableIfNotExists<T extends Table, D extends DataClass>(
-    TableInfo<T, D> table,
-  ) async {
-    await createTable(table);
   }
 
   /// 指定したカラムが存在しない場合のみ追加する。
@@ -148,25 +144,32 @@ Future<void> saveMigrationErrorReport(MigrationErrorReport report) async {
   final file = File(
     p.join(
       docsDir.path,
-      'novelty_migration_error_report_$timestamp.json',
+      '$_migrationReportFilePrefix$timestamp.json',
     ),
   );
   await file.writeAsString(jsonEncode(report.toJson()));
 }
 
-/// 既存のマイグレーションエラーレポートファイルをすべて削除する。
-/// マイグレーション成功後に呼び出すことを想定している。
-Future<void> clearMigrationErrorReports() async {
+/// 保存されているマイグレーションエラーレポートファイルを一覧返す。
+/// 更新日時が新しい順にソートされる。
+Future<List<File>> listMigrationErrorReports() async {
   final docsDir = await getApplicationDocumentsDirectory();
-  final files = docsDir
+  return docsDir
       .listSync()
       .whereType<File>()
       .where(
         (file) =>
-            p.basename(file.path).startsWith('novelty_migration_error_report_')
-            &&
+            p.basename(file.path).startsWith(_migrationReportFilePrefix) &&
             p.basename(file.path).endsWith('.json'),
-      );
+      )
+      .toList()
+    ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+}
+
+/// 既存のマイグレーションエラーレポートファイルをすべて削除する。
+/// マイグレーション成功後に呼び出すことを想定している。
+Future<void> clearMigrationErrorReports() async {
+  final files = await listMigrationErrorReports();
   for (final file in files) {
     await file.delete();
   }

--- a/lib/database/migration_helper.dart
+++ b/lib/database/migration_helper.dart
@@ -101,14 +101,8 @@ class MigrationErrorReport {
 /// マイグレーションエラーレポートファイル名の接頭辞。
 const String _migrationReportFilePrefix = 'novelty_migration_error_report_';
 
-/// [Migrator] に冪等・原子なマイグレーションを支援するための拡張メソッド。
+/// [Migrator] に冪等なマイグレーションを支援するための拡張メソッド。
 extension MigratorHelpers on Migrator {
-  /// 指定したアクションをトランザクション内で実行する。
-  /// マイグレーション内の全操作を原子化するために使用する。
-  Future<void> runInTransaction(Future<void> Function() action) async {
-    await database.transaction(action);
-  }
-
   /// 指定したカラムが存在しない場合のみ追加する。
   Future<void> addColumnIfNotExists<T extends Table, D extends DataClass>(
     TableInfo<T, D> table,
@@ -155,16 +149,18 @@ Future<void> saveMigrationErrorReport(MigrationErrorReport report) async {
 /// 更新日時が新しい順にソートされる。
 Future<List<File>> listMigrationErrorReports() async {
   final docsDir = await getApplicationDocumentsDirectory();
-  return docsDir
-      .listSync()
-      .whereType<File>()
-      .where(
-        (file) =>
-            p.basename(file.path).startsWith(_migrationReportFilePrefix) &&
-            p.basename(file.path).endsWith('.json'),
-      )
-      .toList()
-    ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+  final files = <File>[];
+  await for (final entity in docsDir.list()) {
+    if (entity is File) {
+      final basename = p.basename(entity.path);
+      if (basename.startsWith(_migrationReportFilePrefix) &&
+          basename.endsWith('.json')) {
+        files.add(entity);
+      }
+    }
+  }
+  files.sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+  return files;
 }
 
 /// 既存のマイグレーションエラーレポートファイルをすべて削除する。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,7 +54,6 @@ class MyApp extends ConsumerWidget {
         return MaterialApp(
           home: MigrationRecoveryScreen(
             error: err,
-            stackTrace: stack,
             onRetry: () {
               ref.invalidate(appDatabaseProvider);
               ref.read(migrationRetryCounterProvider.notifier).state++;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:novelty/database/database.dart';
 import 'package:novelty/router/router.dart';
+import 'package:novelty/screens/migration_progress_splash.dart';
+import 'package:novelty/screens/migration_recovery_screen.dart';
+import 'package:novelty/services/backup_service.dart';
 import 'package:novelty/utils/settings_provider.dart';
+import 'package:riverpod/legacy.dart' show StateProvider;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -14,11 +19,59 @@ Future<void> main() async {
   );
 }
 
+/// マイグレーションリトライ回数を管理するプロバイダー。
+final StateProvider<int> migrationRetryCounterProvider = StateProvider<int>(
+  (ref) => 0,
+);
+
+/// データベースの初期化（マイグレーション含む）を管理する FutureProvider。
+final FutureProvider<AppDatabase> databaseInitializationProvider =
+    FutureProvider<AppDatabase>((ref) async {
+  ref.watch(migrationRetryCounterProvider);
+  final db = ref.watch(appDatabaseProvider);
+  await db.doWhenOpened((_) async {});
+  return db;
+});
+
 /// アプリケーションのエントリーポイント。
-/// アプリの設定を初期化し、ルーターを設定してアプリを起動
+/// データベースの初期化状態に応じて、進捗スプラッシュ、リカバリー画面、
+/// または通常のメイン画面を表示する。
 class MyApp extends ConsumerWidget {
   /// コンストラクタ。
   const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dbInit = ref.watch(databaseInitializationProvider);
+
+    return dbInit.when(
+      data: (_) => const _AppWithSettings(),
+      loading: () => const MaterialApp(
+        home: MigrationProgressSplash(),
+      ),
+      error: (err, stack) {
+        final db = ref.read(appDatabaseProvider);
+        return MaterialApp(
+          home: MigrationRecoveryScreen(
+            error: err,
+            stackTrace: stack,
+            onRetry: () {
+              ref.invalidate(appDatabaseProvider);
+              ref.read(migrationRetryCounterProvider.notifier).state++;
+            },
+            onExportDatabase: () async {
+              await BackupService(db).exportDatabaseToFile();
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// 設定を読み込み、テーマとルーターを適用したメインアプリ。
+class _AppWithSettings extends ConsumerWidget {
+  const _AppWithSettings();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -26,7 +79,7 @@ class MyApp extends ConsumerWidget {
 
     return settings.when(
       data: (settings) => DynamicColorBuilder(
-        builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+        builder: (lightDynamic, darkDynamic) {
           final colorScheme =
               lightDynamic ??
               ColorScheme.fromSeed(

--- a/lib/screens/migration_progress_splash.dart
+++ b/lib/screens/migration_progress_splash.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// マイグレーション実行中に表示する進捗スプラッシュ画面。
+/// 長時間かかる処理中にユーザーが誤ってアプリを終了しないよう、
+/// 明示的なメッセージを表示する。
+class MigrationProgressSplash extends StatelessWidget {
+  /// コンストラクタ
+  const MigrationProgressSplash({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 24),
+              Text(
+                '読書データを最新の状態に更新しています。',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 12),
+              Text(
+                '時間がかかる場合がありますが、画面を閉じずにお待ちください。',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/migration_recovery_screen.dart
+++ b/lib/screens/migration_recovery_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -22,7 +23,7 @@ class MigrationRecoveryScreen extends StatelessWidget {
   final VoidCallback? onRetry;
 
   /// DBエクスポートボタンが押されたときに呼ばれるコールバック
-  final VoidCallback? onExportDatabase;
+  final Future<void> Function()? onExportDatabase;
 
   @override
   Widget build(BuildContext context) {
@@ -82,13 +83,13 @@ class MigrationRecoveryScreen extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             OutlinedButton.icon(
-              onPressed: onExportDatabase,
+              onPressed: () => _onExport(context),
               icon: const Icon(Icons.save_alt),
               label: const Text('データベースをエクスポート'),
             ),
             const SizedBox(height: 8),
             OutlinedButton.icon(
-              onPressed: () => _shareLatestReport(context),
+              onPressed: () => unawaited(_shareLatestReport(context)),
               icon: const Icon(Icons.share),
               label: const Text('エラーレポートを共有'),
             ),
@@ -96,6 +97,21 @@ class MigrationRecoveryScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _onExport(BuildContext context) async {
+    if (onExportDatabase == null) {
+      return;
+    }
+    try {
+      await onExportDatabase!();
+    } on Exception catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エクスポートに失敗しました: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _shareLatestReport(BuildContext context) async {

--- a/lib/screens/migration_recovery_screen.dart
+++ b/lib/screens/migration_recovery_screen.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// マイグレーション失敗時に表示するリカバリー画面。
+/// リトライ、DBのエクスポート、エラーレポートの共有を提供する。
+class MigrationRecoveryScreen extends StatelessWidget {
+  /// コンストラクタ
+  const MigrationRecoveryScreen({
+    required this.error,
+    super.key,
+    this.stackTrace,
+    this.onRetry,
+    this.onExportDatabase,
+  });
+
+  /// マイグレーション失敗の原因となった例外
+  final Object error;
+
+  /// スタックトレース
+  final StackTrace? stackTrace;
+
+  /// リトライボタンが押されたときに呼ばれるコールバック
+  final VoidCallback? onRetry;
+
+  /// DBエクスポートボタンが押されたときに呼ばれるコールバック
+  final VoidCallback? onExportDatabase;
+
+  @override
+  Widget build(BuildContext context) {
+    final errorMessage = error.toString();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('データベースの更新に失敗しました'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              color: Colors.red,
+              size: 64,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '読書データの更新中に問題が発生しました。',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '同じ問題が続く場合は、以下のボタンから'
+              'エラーレポートを送付してください。',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color:
+                        Theme.of(context).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    errorMessage,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('もう一度試す'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: onExportDatabase,
+              icon: const Icon(Icons.save_alt),
+              label: const Text('データベースをエクスポート'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: () => _shareLatestReport(context),
+              icon: const Icon(Icons.share),
+              label: const Text('エラーレポートを共有'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _shareLatestReport(BuildContext context) async {
+    try {
+      final latestReport = await _findLatestMigrationReport();
+      if (latestReport != null) {
+        await SharePlus.instance.share(
+          ShareParams(
+            files: [XFile(latestReport.path)],
+            subject: 'Novelty マイグレーションエラーレポート',
+          ),
+        );
+      } else {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('エラーレポートが見つかりませんでした')),
+          );
+        }
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('レポートの共有に失敗しました: $e')),
+        );
+      }
+    }
+  }
+
+  Future<File?> _findLatestMigrationReport() async {
+    final docsDir = await getApplicationDocumentsDirectory();
+    final files = docsDir
+        .listSync()
+        .whereType<File>()
+        .where(
+          (file) =>
+              p.basename(file.path)
+                  .startsWith('novelty_migration_error_report_') &&
+              p.basename(file.path).endsWith('.json'),
+        )
+        .toList();
+    if (files.isEmpty) {
+      return null;
+    }
+    files.sort(
+      (a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()),
+    );
+    return files.first;
+  }
+}

--- a/lib/screens/migration_recovery_screen.dart
+++ b/lib/screens/migration_recovery_screen.dart
@@ -1,8 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
+import 'package:novelty/database/migration_helper.dart';
 import 'package:share_plus/share_plus.dart';
 
 /// マイグレーション失敗時に表示するリカバリー画面。
@@ -12,16 +11,12 @@ class MigrationRecoveryScreen extends StatelessWidget {
   const MigrationRecoveryScreen({
     required this.error,
     super.key,
-    this.stackTrace,
     this.onRetry,
     this.onExportDatabase,
   });
 
   /// マイグレーション失敗の原因となった例外
   final Object error;
-
-  /// スタックトレース
-  final StackTrace? stackTrace;
 
   /// リトライボタンが押されたときに呼ばれるコールバック
   final VoidCallback? onRetry;
@@ -130,23 +125,7 @@ class MigrationRecoveryScreen extends StatelessWidget {
   }
 
   Future<File?> _findLatestMigrationReport() async {
-    final docsDir = await getApplicationDocumentsDirectory();
-    final files = docsDir
-        .listSync()
-        .whereType<File>()
-        .where(
-          (file) =>
-              p.basename(file.path)
-                  .startsWith('novelty_migration_error_report_') &&
-              p.basename(file.path).endsWith('.json'),
-        )
-        .toList();
-    if (files.isEmpty) {
-      return null;
-    }
-    files.sort(
-      (a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()),
-    );
-    return files.first;
+    final files = await listMigrationErrorReports();
+    return files.isEmpty ? null : files.first;
   }
 }

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -15,7 +15,9 @@ class BackupService {
   final AppDatabase _database;
 
   /// 現在のスキーマバージョン
-  static const int currentSchemaVersion = 11;
+  /// AppDatabase.currentSchemaVersion と常に同期させることで、
+  /// バックアップ名とマイグレーション判定の信頼性を保つ。
+  static int get currentSchemaVersion => AppDatabase.currentSchemaVersion;
 
   /// データベース全体をエクスポートする
   ///

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -45,7 +45,8 @@ class BackupService {
 
       // バックアップファイル名を生成(スキーマバージョンを含める)
       final fileName =
-          'novelty_backup_${_formatDateTime(DateTime.now())}_v$currentSchemaVersion.db';
+          'novelty_backup_${_formatDateTime(DateTime.now())}'
+          '_v$currentSchemaVersion.db';
       final backupPath = p.join(selectedDirectory, fileName);
 
       // データベースファイルをコピー
@@ -125,7 +126,13 @@ class BackupService {
 
   /// 日時をファイル名用にフォーマットする
   String _formatDateTime(DateTime dateTime) {
-    return '${dateTime.year}${dateTime.month.toString().padLeft(2, '0')}${dateTime.day.toString().padLeft(2, '0')}_${dateTime.hour.toString().padLeft(2, '0')}${dateTime.minute.toString().padLeft(2, '0')}${dateTime.second.toString().padLeft(2, '0')}';
+    final year = dateTime.year;
+    final month = dateTime.month.toString().padLeft(2, '0');
+    final day = dateTime.day.toString().padLeft(2, '0');
+    final hour = dateTime.hour.toString().padLeft(2, '0');
+    final minute = dateTime.minute.toString().padLeft(2, '0');
+    final second = dateTime.second.toString().padLeft(2, '0');
+    return '$year$month${day}_$hour$minute$second';
   }
 }
 

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -210,12 +210,83 @@ void main() {
     db.dispose();
   }
 
+  /// 中断により episode_list_entries / episode_contents が不完全なデータで
+  /// 存在する壊れた v15 DB を作成する。
+  Future<void> createBrokenV15DatabaseWithIncompleteEntries(File file) async {
+    final db = sqlite3.open(file.path);
+
+    const statements = <String>[
+      'CREATE TABLE novels (ncode TEXT NOT NULL PRIMARY KEY, title TEXT)',
+      '''
+      CREATE TABLE episodes (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        subtitle TEXT,
+        url TEXT,
+        published_at TEXT,
+        revised_at TEXT,
+        content TEXT,
+        fetched_at INTEGER,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      "INSERT INTO novels (ncode, title) VALUES ('n1234ab', 'テスト小説')",
+      '''
+      INSERT INTO episodes VALUES (
+        'n1234ab', 1, '第1話', 'https://example.com/1',
+        '2024-01-01 00:00:00', '2024-01-02 00:00:00',
+        '[{"runtimeType":"plainText","text":"本文"}]', 1000)
+      ''',
+      '''
+      CREATE TABLE episode_list_entries (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        subtitle TEXT,
+        url TEXT,
+        published_at TEXT,
+        revised_at TEXT,
+        fetched_at INTEGER,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      '''
+      CREATE TABLE episode_contents (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        content TEXT,
+        fetched_at INTEGER,
+        revised_at TEXT,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      // 不完全な目次データ（subtitle 等が NULL）
+      '''
+      INSERT INTO episode_list_entries (ncode, episode_id)
+      VALUES ('n1234ab', 1)
+      ''',
+      // 不完全な本文データ（content 等が NULL）
+      '''
+      INSERT INTO episode_contents (ncode, episode_id)
+      VALUES ('n1234ab', 1)
+      ''',
+      'PRAGMA user_version = 15',
+    ];
+
+    // 可読性のためforEachは使用しない
+    // ignore: prefer_foreach
+    for (final sql in statements) {
+      db.execute(sql);
+    }
+    db.dispose();
+  }
+
   test('v15マイグレーション失敗時にMigrationExceptionが投げられること', () async {
     await createBrokenSchemaV15Database(dbFile);
 
     await expectLater(
       () async {
         final db = AppDatabase.test(NativeDatabase(dbFile));
+        addTearDown(db.close);
         await db.doWhenOpened((_) async {});
         return db;
       },
@@ -262,6 +333,33 @@ void main() {
     final novel = await db.getNovel('n1234ab');
     expect(novel, isNotNull);
     expect(novel!.isPrivate, isFalse);
+  });
+
+  test('v15中間状態からの修復：不完全な目次・本文行が episodes の値で上書きされること', () async {
+    await createBrokenV15DatabaseWithIncompleteEntries(dbFile);
+
+    final db = AppDatabase.test(NativeDatabase(dbFile));
+    addTearDown(db.close);
+
+    // 目次行の値が episodes 側の完全な値で修復されていること
+    final listRows = await db.select(db.episodeListEntries).get();
+    expect(listRows.length, 1);
+    final listRow = listRows.single;
+    expect(listRow.episodeId, 1);
+    expect(listRow.subtitle, '第1話');
+    expect(listRow.url, 'https://example.com/1');
+    expect(listRow.publishedAt, '2024-01-01 00:00:00');
+    expect(listRow.revisedAt, '2024-01-02 00:00:00');
+
+    // 本文行の値が episodes 側の完全な値で修復されていること
+    final contentRows = await db.select(db.episodeContents).get();
+    expect(contentRows.length, 1);
+    final contentRow = contentRows.single;
+    expect(contentRow.episodeId, 1);
+    expect(contentRow.content, isNotNull);
+    expect(contentRow.content!.length, 1);
+    expect(contentRow.fetchedAt, 1000);
+    expect(contentRow.revisedAt, '2024-01-02 00:00:00');
   });
 
   test('v15からのアップグレードで目次・本文が新テーブルに引き継がれること', () async {

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -97,7 +97,7 @@ void main() {
         PRIMARY KEY (ncode, episode_id)
       )
       ''',
-      'INSERT INTO novels (ncode, title) VALUES (\'n1234ab\', \'テスト小説\')',
+      "INSERT INTO novels (ncode, title) VALUES ('n1234ab', 'テスト小説')",
       '''
       INSERT INTO episodes VALUES (
         'n1234ab', 1, '第1話', 'https://example.com/1',
@@ -156,11 +156,78 @@ void main() {
       'PRAGMA user_version = 15',
     ];
 
+    // 可読性のためforEachは使用しない
+    // ignore: prefer_foreach
     for (final sql in statements) {
       db.execute(sql);
     }
     db.dispose();
   }
+
+  /// 中断により episode_list_entries が不完全なスキーマで存在する
+  /// 壊れた v15 DB を作成する。
+  Future<void> createBrokenSchemaV15Database(File file) async {
+    final db = sqlite3.open(file.path);
+
+    const statements = <String>[
+      'CREATE TABLE novels (ncode TEXT NOT NULL PRIMARY KEY, title TEXT)',
+      '''
+      CREATE TABLE episodes (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        subtitle TEXT,
+        url TEXT,
+        published_at TEXT,
+        revised_at TEXT,
+        content TEXT,
+        fetched_at INTEGER,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      "INSERT INTO novels (ncode, title) VALUES ('n1234ab', 'テスト小説')",
+      '''
+      INSERT INTO episodes VALUES (
+        'n1234ab', 1, '第1話', 'https://example.com/1',
+        '2024-01-01 00:00:00', '2024-01-02 00:00:00',
+        '[{"runtimeType":"plainText","text":"本文"}]', 1000)
+      ''',
+      // 不完全なスキーマで episode_list_entries が作成されている
+      '''
+      CREATE TABLE episode_list_entries (
+        ncode TEXT NOT NULL,
+        episode_id INTEGER NOT NULL,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      'PRAGMA user_version = 15',
+    ];
+
+    // 可読性のためforEachは使用しない
+    // ignore: prefer_foreach
+    for (final sql in statements) {
+      db.execute(sql);
+    }
+    db.dispose();
+  }
+
+  test('v15マイグレーション失敗時にMigrationExceptionが投げられること', () async {
+    await createBrokenSchemaV15Database(dbFile);
+
+    await expectLater(
+      () async {
+        final db = AppDatabase.test(NativeDatabase(dbFile));
+        await db.doWhenOpened((_) async {});
+        return db;
+      },
+      throwsA(
+        isA<MigrationException>().having(
+          (e) => e.toVersion,
+          'toVersion',
+          16,
+        ),
+      ),
+    );
+  });
 
   test('v15中間状態からの修復：目次・本文が重複せず正常に完了すること', () async {
     await createBrokenV15Database(dbFile);
@@ -297,6 +364,7 @@ void main() {
       'PRAGMA user_version = 14',
     ];
 
+    // 可読性のためforEachは使用しない
     // ignore: prefer_foreach
     for (final sql in statements) {
       db.execute(sql);

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -76,6 +76,127 @@ void main() {
     db.dispose();
   }
 
+  /// 中断により中間状態が残った v15 相当の DB を作成する。
+  /// episode_list_entries / episode_contents が既に存在し、
+  /// episodes テーブルもまだ残っている状態を再現する。
+  Future<void> createBrokenV15Database(File file) async {
+    final db = sqlite3.open(file.path);
+
+    const statements = <String>[
+      'CREATE TABLE novels (ncode TEXT NOT NULL PRIMARY KEY, title TEXT)',
+      '''
+      CREATE TABLE episodes (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        subtitle TEXT,
+        url TEXT,
+        published_at TEXT,
+        revised_at TEXT,
+        content TEXT,
+        fetched_at INTEGER,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      'INSERT INTO novels (ncode, title) VALUES (\'n1234ab\', \'テスト小説\')',
+      '''
+      INSERT INTO episodes VALUES (
+        'n1234ab', 1, '第1話', 'https://example.com/1',
+        '2024-01-01 00:00:00', '2024-01-02 00:00:00',
+        '[{"runtimeType":"plainText","text":"本文"}]', 1000)
+      ''',
+      '''
+      INSERT INTO episodes VALUES (
+        'n1234ab', 2, '第2話', 'https://example.com/2',
+        '2024-01-01 00:00:00', NULL, '[]', 2000)
+      ''',
+      '''
+      INSERT INTO episodes
+        (ncode, episode_id, subtitle, url, published_at, revised_at)
+      VALUES (
+        'n1234ab', 3, '第3話', 'https://example.com/3',
+        '2024-01-03 00:00:00', '2024-01-04 00:00:00')
+      ''',
+      // マイグレーションが中断された状態：目次・本文テーブルは存在するが
+      // user_version や is_private カラムは更新されていない
+      '''
+      CREATE TABLE episode_list_entries (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        subtitle TEXT,
+        url TEXT,
+        published_at TEXT,
+        revised_at TEXT,
+        fetched_at INTEGER,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      '''
+      CREATE TABLE episode_contents (
+        ncode TEXT NOT NULL REFERENCES novels(ncode),
+        episode_id INTEGER NOT NULL,
+        content TEXT,
+        fetched_at INTEGER,
+        revised_at TEXT,
+        PRIMARY KEY (ncode, episode_id)
+      )
+      ''',
+      '''
+      INSERT INTO episode_list_entries
+        (ncode, episode_id, subtitle, url, published_at, revised_at, fetched_at)
+      SELECT ncode, episode_id, subtitle, url, published_at, revised_at, NULL
+      FROM episodes
+      ''',
+      '''
+      INSERT INTO episode_contents
+        (ncode, episode_id, content, fetched_at, revised_at)
+      SELECT ncode, episode_id, content, fetched_at, revised_at
+      FROM episodes
+      WHERE content IS NOT NULL
+      ''',
+      'PRAGMA user_version = 15',
+    ];
+
+    for (final sql in statements) {
+      db.execute(sql);
+    }
+    db.dispose();
+  }
+
+  test('v15中間状態からの修復：目次・本文が重複せず正常に完了すること', () async {
+    await createBrokenV15Database(dbFile);
+
+    final db = AppDatabase.test(NativeDatabase(dbFile));
+    addTearDown(db.close);
+
+    // 目次は3件保持されていること
+    final listRows = await db.select(db.episodeListEntries).get();
+    expect(listRows.length, 3);
+
+    // 本文は2件保持されていること
+    final contentRows = await db.select(db.episodeContents).get();
+    expect(contentRows.length, 2);
+
+    // 旧テーブルが削除されていること
+    final oldTables = await db
+        .customSelect(
+          'SELECT name FROM sqlite_master '
+          "WHERE type='table' AND name='episodes'",
+        )
+        .get();
+    expect(oldTables, isEmpty);
+
+    // スキーマバージョンが16に更新されていること
+    final versionResult = await db
+        .customSelect('PRAGMA user_version')
+        .getSingle();
+    expect(versionResult.read<int>('user_version'), 16);
+
+    // novelsに非公開フラグが追加されていること
+    final novel = await db.getNovel('n1234ab');
+    expect(novel, isNotNull);
+    expect(novel!.isPrivate, isFalse);
+  });
+
   test('v15からのアップグレードで目次・本文が新テーブルに引き継がれること', () async {
     await createV15Database(dbFile);
 

--- a/test/screens/migration_ui_test.dart
+++ b/test/screens/migration_ui_test.dart
@@ -62,7 +62,7 @@ void main() {
         MaterialApp(
           home: MigrationRecoveryScreen(
             error: Exception('test error'),
-            onExportDatabase: () {
+            onExportDatabase: () async {
               exportCalled = true;
             },
           ),

--- a/test/screens/migration_ui_test.dart
+++ b/test/screens/migration_ui_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:novelty/screens/migration_progress_splash.dart';
+import 'package:novelty/screens/migration_recovery_screen.dart';
+
+void main() {
+  group('MigrationProgressSplash', () {
+    testWidgets('更新メッセージが表示されること', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: MigrationProgressSplash()),
+      );
+
+      expect(find.text('読書データを最新の状態に更新しています。'), findsOneWidget);
+      expect(
+        find.text('時間がかかる場合がありますが、画面を閉じずにお待ちください。'),
+        findsOneWidget,
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+
+  group('MigrationRecoveryScreen', () {
+    testWidgets('エラーメッセージと各ボタンが表示されること', (tester) async {
+      const errorMessage = 'Exception: test error';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MigrationRecoveryScreen(
+            error: Exception('test error'),
+          ),
+        ),
+      );
+
+      expect(find.text('データベースの更新に失敗しました'), findsOneWidget);
+      expect(find.text(errorMessage), findsOneWidget);
+      expect(find.text('もう一度試す'), findsOneWidget);
+      expect(find.text('データベースをエクスポート'), findsOneWidget);
+      expect(find.text('エラーレポートを共有'), findsOneWidget);
+    });
+
+    testWidgets('リトライボタンを押すとコールバックが呼ばれること', (tester) async {
+      var retryCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MigrationRecoveryScreen(
+            error: Exception('test error'),
+            onRetry: () {
+              retryCalled = true;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('もう一度試す'));
+      await tester.pump();
+
+      expect(retryCalled, isTrue);
+    });
+
+    testWidgets('エクスポートボタンを押すとコールバックが呼ばれること', (tester) async {
+      var exportCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MigrationRecoveryScreen(
+            error: Exception('test error'),
+            onExportDatabase: () {
+              exportCalled = true;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('データベースをエクスポート'));
+      await tester.pump();
+
+      expect(exportCalled, isTrue);
+    });
+  });
+}

--- a/test/services/backup_service_test.dart
+++ b/test/services/backup_service_test.dart
@@ -20,6 +20,13 @@ void main() {
       expect(backupService, isA<BackupService>());
     });
 
+    test('currentSchemaVersionはAppDatabase.currentSchemaVersionと一致する', () {
+      expect(
+        BackupService.currentSchemaVersion,
+        AppDatabase.currentSchemaVersion,
+      );
+    });
+
     // ファイル選択ダイアログが関わるため、実際のテストはUIテストで行う
     // ここでは基本的なインスタンス化のみテスト
   });


### PR DESCRIPTION
## 概要

v0.21.0 から v0.22.0 への DB マイグレーションが中断すると、後続の起動で UNIQUE 制約違反などにより履歴・ライブラリが開けなくなる問題を修正します。

## 変更内容

- `onUpgrade` をトランザクション内で実行し、マイグレーションを原子化
- `INSERT OR IGNORE` や存在確認を使い、冪等なマイグレーションに変更
- v15 中間状態（テーブル分割が途中まで適用済み）からの自動修復を実装
- マイグレーション失敗時に JSON エラーレポートを保存し、`MigrationException` をスロー
- マイグレーション進捗スプラッシュとリカバリー画面を追加
- `BackupService.currentSchemaVersion` を `AppDatabase.currentSchemaVersion` と同期

## レビュー対応

- `listMigrationErrorReports()` を導入しレポート探索ロジックの重複を除去
- `createTableIfNotExists` ラッパーを削除
- 未使用の `appVersion` / `stackTrace` フィールドを削除
- `MigrationErrorReport.fromException()` で重複フィールドを整理

## 確認事項

- `mise run analyze` で新規/変更ファイルに Lint 違反なし
- 関連テスト（`migration_test.dart`, `backup_service_test.dart`, `migration_ui_test.dart`）が全件パス
- 全体テストでは既存の失敗（Golden テスト等）が 22 件残存（本変更とは無関係）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - マイグレーション中の進捗画面を追加。
  - 失敗時の復旧画面（再試行／DBエクスポート／エラーレポート共有）を追加。
  - マイグレーション失敗レポートの保存・一覧・削除に対応。
- **改善**
  - 起動時にDB状態へ応じた分岐で復旧フローを強化。
- **テスト**
  - 移行UI・移行処理・バックアップのテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->