### PR TITLE
feat: DBインポート/エクスポートを最上位状態としてブロックし、フィードバックを必須化

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1049,21 +1049,20 @@ class AppDatabase extends _$AppDatabase {
         final contentJson = row.read<String?>('content');
         if (contentJson == null) continue;
 
-        final tokenizedSubtitle =
-            SearchTokenizer.tokenize(row.read<String?>('subtitle') ?? '');
+        final tokenizedSubtitle = SearchTokenizer.tokenize(
+          row.read<String?>('subtitle') ?? '',
+        );
 
         // 本文コンテンツから検索用テキストを抽出する
         final buffer = StringBuffer();
-        for (final element
-            in const ContentConverter().fromSql(contentJson)) {
+        for (final element in const ContentConverter().fromSql(contentJson)) {
           if (element is PlainText) {
             buffer.write(element.text);
           } else if (element is RubyText) {
             buffer.write(element.base);
           }
         }
-        final tokenizedContent =
-            SearchTokenizer.tokenize(buffer.toString());
+        final tokenizedContent = SearchTokenizer.tokenize(buffer.toString());
 
         batch.customStatement(
           'INSERT INTO episodes_search('
@@ -1793,14 +1792,14 @@ class AppDatabase extends _$AppDatabase {
     String workId,
     int episodeId,
   ) async {
-    final row = await (select(episodeListEntries)
-          ..where(
-            (e) =>
-                e.source.equalsValue(source) &
-                e.workId.equals(workId) &
-                e.episodeId.equals(episodeId),
-          ))
-        .getSingleOrNull();
+    final row =
+        await (select(episodeListEntries)..where(
+              (e) =>
+                  e.source.equalsValue(source) &
+                  e.workId.equals(workId) &
+                  e.episodeId.equals(episodeId),
+            ))
+            .getSingleOrNull();
     return row?.url;
   }
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1007,11 +1007,31 @@ class AppDatabase extends _$AppDatabase {
   }
 
   Future<void> _populateFtsTables() async {
+    // マイグレーションなどで一から再構築する際、
+    // 行ごとの INSERT OR REPLACE + rowid 解決は遅いため、
+    // 空のFTSテーブルへの一括 INSERT に切り替える。
+    // （FTSテーブルは呼び出し元で DROP & CREATE 済みの前提）
+
     // Novels検索インデックスを再構築
     final allNovels = await select(novels).get();
-    for (final novel in allNovels) {
-      await _updateNovelSearchIndex(novel);
-    }
+    await batch((batch) {
+      for (final novel in allNovels) {
+        final tokenizedTitle = SearchTokenizer.tokenize(novel.title ?? '');
+        final tokenizedWriter = SearchTokenizer.tokenize(novel.writer ?? '');
+        final tokenizedStory = SearchTokenizer.tokenize(novel.story ?? '');
+        batch.customStatement(
+          'INSERT INTO novels_search(source, work_id, title, writer, story) '
+          'VALUES (?, ?, ?, ?, ?)',
+          [
+            novel.source.dbId,
+            novel.workId,
+            tokenizedTitle,
+            tokenizedWriter,
+            tokenizedStory,
+          ],
+        );
+      }
+    });
 
     // Episodes検索インデックスを再構築
     final episodeRows = await customSelect(
@@ -1023,17 +1043,42 @@ class AppDatabase extends _$AppDatabase {
       'WHERE c.content IS NOT NULL',
       readsFrom: {episodeListEntries, episodeContents},
     ).get();
-    for (final row in episodeRows) {
-      final contentJson = row.read<String?>('content');
-      if (contentJson == null) continue;
-      await _updateEpisodeSearchIndex(
-        source: NovelSource.values.byName(row.read<String>('source')),
-        workId: row.read<String>('work_id'),
-        episodeId: row.read<int>('episode_id'),
-        subtitle: row.read<String?>('subtitle'),
-        content: const ContentConverter().fromSql(contentJson),
-      );
-    }
+
+    await batch((batch) {
+      for (final row in episodeRows) {
+        final contentJson = row.read<String?>('content');
+        if (contentJson == null) continue;
+
+        final tokenizedSubtitle =
+            SearchTokenizer.tokenize(row.read<String?>('subtitle') ?? '');
+
+        // 本文コンテンツから検索用テキストを抽出する
+        final buffer = StringBuffer();
+        for (final element
+            in const ContentConverter().fromSql(contentJson)) {
+          if (element is PlainText) {
+            buffer.write(element.text);
+          } else if (element is RubyText) {
+            buffer.write(element.base);
+          }
+        }
+        final tokenizedContent =
+            SearchTokenizer.tokenize(buffer.toString());
+
+        batch.customStatement(
+          'INSERT INTO episodes_search('
+          ' source, work_id, episode_id, subtitle, content) '
+          'VALUES (?, ?, ?, ?, ?)',
+          [
+            row.read<String>('source'),
+            row.read<String>('work_id'),
+            row.read<int>('episode_id'),
+            tokenizedSubtitle,
+            tokenizedContent,
+          ],
+        );
+      }
+    });
   }
 
   /// 小説の検索インデックスを更新

--- a/lib/database/database_initialization.dart
+++ b/lib/database/database_initialization.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:novelty/database/database.dart';
+import 'package:riverpod/legacy.dart' show StateProvider;
+
+/// マイグレーションリトライ回数を管理するプロバイダー。
+final StateProvider<int> migrationRetryCounterProvider = StateProvider<int>(
+  (ref) => 0,
+);
+
+/// データベースの初期化（マイグレーション含む）を管理する FutureProvider。
+final FutureProvider<AppDatabase> databaseInitializationProvider =
+    FutureProvider<AppDatabase>((ref) async {
+      ref.watch(migrationRetryCounterProvider);
+      final db = ref.watch(appDatabaseProvider);
+      await db.doWhenOpened((_) async {});
+      return db;
+    });

--- a/lib/database/database_maintenance.dart
+++ b/lib/database/database_maintenance.dart
@@ -16,16 +16,50 @@ class DatabaseMaintenanceIdle extends DatabaseMaintenanceState {
   const DatabaseMaintenanceIdle();
 }
 
+/// インポート適用(DBファイルの置き換え)に必要な情報。
+class ImportSwapPayload {
+  /// コンストラクタ
+  const ImportSwapPayload({required this.pendingFilePath, this.backupVersion});
+
+  /// ステージング済みの新しいDBファイルのパス
+  final String pendingFilePath;
+
+  /// バックアップファイルのスキーマバージョン
+  final int? backupVersion;
+}
+
 /// 保守操作の実行中。
 ///
 /// [operationLabel] には「データベースをインポートしています…」のような
 /// ユーザー向けの操作説明を設定する。
 class DatabaseMaintenanceBusy extends DatabaseMaintenanceState {
   /// コンストラクタ
-  const DatabaseMaintenanceBusy(this.operationLabel);
+  const DatabaseMaintenanceBusy(this.operationLabel, {this.importSwap});
 
   /// ユーザー向けの操作説明
   final String operationLabel;
+
+  /// インポート適用(DBファイル置き換え)の情報。
+  ///
+  /// 非nullの場合、アプリルートは配下の画面を全てアンマウントして
+  /// ブロッキング画面のみを表示する。これによりDBへのストリーム購読が
+  /// 全てキャンセルされ、安全にDBをクローズできる。
+  /// (pause状態の購読が残っているとDriftのclose()は完了しない)
+  final ImportSwapPayload? importSwap;
+}
+
+/// インポート適用(DBファイル置き換え)の結果。
+///
+/// 再初期化後に一度だけスナックバーで通知して消費する。
+class ImportSwapResult {
+  /// コンストラクタ
+  const ImportSwapResult({required this.success, this.error});
+
+  /// 置き換えに成功したかどうか
+  final bool success;
+
+  /// 失敗時のエラー内容
+  final String? error;
 }
 
 /// データベース保守操作の実行状態を管理するプロバイダー。
@@ -36,6 +70,12 @@ final StateProvider<DatabaseMaintenanceState> databaseMaintenanceProvider =
     StateProvider<DatabaseMaintenanceState>(
       (ref) => const DatabaseMaintenanceIdle(),
     );
+
+/// インポート適用の結果を保持するプロバイダー。
+///
+/// 適用処理がセットし、再初期化後のUIが一度だけ消費する。
+final StateProvider<ImportSwapResult?> importSwapResultProvider =
+    StateProvider<ImportSwapResult?>((ref) => null);
 
 /// 保守操作をブロッキング状態で実行するガードヘルパー。
 ///
@@ -57,4 +97,27 @@ Future<T> runWithDatabaseMaintenance<T>(
     ref.read(databaseMaintenanceProvider.notifier).state =
         const DatabaseMaintenanceIdle();
   }
+}
+
+/// インポート適用(DBファイルの置き換え)フェーズを開始する。
+///
+/// 呼び出すとアプリルートが配下の画面をアンマウントし、DBへの
+/// ストリーム購読が全てキャンセルされたうえでファイル置き換えが
+/// 実行される。呼び出し元の画面もアンマウントされるため、
+/// この呼び出し以降に画面側でフィードバックを表示してはいけない。
+/// 結果は [importSwapResultProvider] にセットされる。
+void startImportSwap(WidgetRef ref, {required ImportSwapPayload payload}) {
+  ref
+      .read(databaseMaintenanceProvider.notifier)
+      .state = DatabaseMaintenanceBusy(
+    'データベースを切り替えています…',
+    importSwap: payload,
+  );
+}
+
+/// インポート適用フェーズを終了し、結果をセットする。
+void finishImportSwap(WidgetRef ref, {required ImportSwapResult result}) {
+  ref.read(importSwapResultProvider.notifier).state = result;
+  ref.read(databaseMaintenanceProvider.notifier).state =
+      const DatabaseMaintenanceIdle();
 }

--- a/lib/database/database_maintenance.dart
+++ b/lib/database/database_maintenance.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/legacy.dart' show StateProvider;
+
+/// DBを停止して行う保守操作(インポート/エクスポート)の実行状態。
+///
+/// 実行中はアプリ全体の操作をブロックするための状態として扱い、
+/// アプリルートで監視してブロッキング画面を重ねて表示する。
+sealed class DatabaseMaintenanceState {
+  /// コンストラクタ
+  const DatabaseMaintenanceState();
+}
+
+/// 保守操作が実行されていない通常状態。
+class DatabaseMaintenanceIdle extends DatabaseMaintenanceState {
+  /// コンストラクタ
+  const DatabaseMaintenanceIdle();
+}
+
+/// 保守操作の実行中。
+///
+/// [operationLabel] には「データベースをインポートしています…」のような
+/// ユーザー向けの操作説明を設定する。
+class DatabaseMaintenanceBusy extends DatabaseMaintenanceState {
+  /// コンストラクタ
+  const DatabaseMaintenanceBusy(this.operationLabel);
+
+  /// ユーザー向けの操作説明
+  final String operationLabel;
+}
+
+/// データベース保守操作の実行状態を管理するプロバイダー。
+///
+/// インポート/エクスポートなど、DBファイルを直接操作する間は
+/// 必ず [DatabaseMaintenanceBusy] にして他の操作をブロックすること。
+final StateProvider<DatabaseMaintenanceState> databaseMaintenanceProvider =
+    StateProvider<DatabaseMaintenanceState>(
+      (ref) => const DatabaseMaintenanceIdle(),
+    );
+
+/// 保守操作をブロッキング状態で実行するガードヘルパー。
+///
+/// 実行中は [DatabaseMaintenanceBusy] にしてアプリ全体の操作をブロックし、
+/// 完了・失敗に関わらず終了時に [DatabaseMaintenanceIdle] へ戻す。
+///
+/// [label] には「データベースをインポートしています…」のような
+/// ユーザー向けの操作説明を指定する。
+Future<T> runWithDatabaseMaintenance<T>(
+  WidgetRef ref, {
+  required String label,
+  required Future<T> Function() task,
+}) async {
+  ref.read(databaseMaintenanceProvider.notifier).state =
+      DatabaseMaintenanceBusy(label);
+  try {
+    return await task();
+  } finally {
+    ref.read(databaseMaintenanceProvider.notifier).state =
+        const DatabaseMaintenanceIdle();
+  }
+}

--- a/lib/database/database_providers.dart
+++ b/lib/database/database_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:novelty/database/database.dart';
 import 'package:novelty/utils/history_grouping.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -6,7 +8,41 @@ part 'database_providers.g.dart';
 
 @Riverpod(keepAlive: true)
 /// アプリケーションデータベースのインスタンスを提供するプロバイダー。
-AppDatabase appDatabase(Ref ref) => AppDatabase();
+///
+/// 再初期化(invalidate)時に旧インスタンスの接続が残り続けると
+/// 同じDBファイルへの接続が多重に開かれるため、破棄時にクローズする。
+AppDatabase appDatabase(Ref ref) {
+  final db = AppDatabase();
+  ref.onDispose(() {
+    unawaited(closeAppDatabaseSafely(db));
+  });
+  return db;
+}
+
+final _closeFutures = <AppDatabase, Future<void>>{};
+
+/// DBのクローズをインスタンスごとに一度だけ実行し、その完了を待つ。
+///
+/// プロバイダー破棄時のクローズと、インポート適用時の明示的な
+/// クローズが競合しないよう、進行中のクローズがあればそれを返す。
+/// (Driftのclose()には二重呼び出しのガードがないため)
+Future<void> closeAppDatabaseSafely(AppDatabase db) {
+  final existing = _closeFutures[db];
+  if (existing != null) {
+    return existing;
+  }
+
+  final future = () async {
+    try {
+      await db.close();
+    } on Object {
+      // 既にクローズ済みの場合などは無視する
+    }
+  }();
+  _closeFutures[db] = future;
+  unawaited(future.whenComplete(() => _closeFutures.remove(db)));
+  return future;
+}
 
 @riverpod
 /// ライブラリに登録されている小説のリストを監視するプロバイダー。

--- a/lib/database/database_providers.g.dart
+++ b/lib/database/database_providers.g.dart
@@ -9,16 +9,25 @@ part of 'database_providers.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 /// アプリケーションデータベースのインスタンスを提供するプロバイダー。
+///
+/// 再初期化(invalidate)時に旧インスタンスの接続が残り続けると
+/// 同じDBファイルへの接続が多重に開かれるため、破棄時にクローズする。
 
 @ProviderFor(appDatabase)
 final appDatabaseProvider = AppDatabaseProvider._();
 
 /// アプリケーションデータベースのインスタンスを提供するプロバイダー。
+///
+/// 再初期化(invalidate)時に旧インスタンスの接続が残り続けると
+/// 同じDBファイルへの接続が多重に開かれるため、破棄時にクローズする。
 
 final class AppDatabaseProvider
     extends $FunctionalProvider<AppDatabase, AppDatabase, AppDatabase>
     with $Provider<AppDatabase> {
   /// アプリケーションデータベースのインスタンスを提供するプロバイダー。
+  ///
+  /// 再初期化(invalidate)時に旧インスタンスの接続が残り続けると
+  /// 同じDBファイルへの接続が多重に開かれるため、破棄時にクローズする。
   AppDatabaseProvider._()
     : super(
         from: null,
@@ -52,7 +61,7 @@ final class AppDatabaseProvider
   }
 }
 
-String _$appDatabaseHash() => r'98a09c6cfd43966155dfbdb0787fa18c85438e13';
+String _$appDatabaseHash() => r'879bfe1ad96d42751dfae1ace4af49c128830f95';
 
 /// ライブラリに登録されている小説のリストを監視するプロバイダー。
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:novelty/database/database.dart';
@@ -53,6 +56,41 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // インポート適用(DBファイル置き換え)の要求を監視する。
+    // Busy状態にpayloadがセットされたら、画面のアンマウントを待ってから
+    // ファイル置き換えを実行する。
+    ref.listen<DatabaseMaintenanceState>(databaseMaintenanceProvider, (
+      previous,
+      next,
+    ) {
+      final swap = next is DatabaseMaintenanceBusy ? next.importSwap : null;
+      final prevSwap = previous is DatabaseMaintenanceBusy
+          ? previous.importSwap
+          : null;
+      if (swap != null && !identical(swap, prevSwap)) {
+        unawaited(_performImportSwap(ref, swap));
+      }
+    });
+
+    final maintenance = ref.watch(databaseMaintenanceProvider);
+    if (maintenance is DatabaseMaintenanceBusy &&
+        maintenance.importSwap != null) {
+      // DBファイル置き換え中は、DB関連プロバイダを一切監視しない
+      // ブロッキング画面のみを表示する。
+      // databaseInitializationProvider等を監視したまま
+      // appDatabaseProviderをinvalidateすると即座に再生成されて
+      // しまい、旧接続のクローズと新接続のオープンが競合するため。
+      return MaterialApp(
+        locale: appLocale,
+        supportedLocales: appSupportedLocales,
+        localizationsDelegates: appLocalizationsDelegates,
+        theme: ThemeData(fontFamily: appUiFontFamily),
+        home: DatabaseMaintenanceScreen(
+          operationLabel: maintenance.operationLabel,
+        ),
+      );
+    }
+
     final dbInit = ref.watch(databaseInitializationProvider);
 
     return dbInit.when(
@@ -84,7 +122,7 @@ class MyApp extends ConsumerWidget {
                 return runWithDatabaseMaintenance(
                   ref,
                   label: 'データベースをエクスポートしています…',
-                  task: () => BackupService(db).exportDatabaseToFile(),
+                  task: () => BackupService(db).exportDatabaseFileDirectly(),
                 );
               },
             ),
@@ -93,6 +131,60 @@ class MyApp extends ConsumerWidget {
       },
     );
   }
+}
+
+/// インポート適用(DBファイルの置き換え)を実行する。
+///
+/// この時点で [DatabaseMaintenanceBusy] にpayloadがセット済みのため、
+/// オーバーレイは配下の画面をアンマウントしている。画面のアンマウントに
+/// よってDBへのストリーム購読が全てキャンセルされてから、
+/// 接続のクローズとファイル置き換えを行う。
+/// (pause状態の購読が残っているとDriftのclose()は完了しないため)
+Future<void> _performImportSwap(
+  WidgetRef ref,
+  ImportSwapPayload payload,
+) async {
+  // フレームの終わりまで待ち、配下画面のアンマウントと
+  // MyApp側のDBプロバイダ監視解除を完了させる
+  await SchedulerBinding.instance.endOfFrame;
+
+  // DBに依存する全プロバイダを破棄し、ストリーム購読を全て
+  // キャンセルさせてから旧接続をクローズする。
+  // keepAliveのストリームプロバイダ(lastReadEpisode等)は
+  // 画面アンマウントだけでは破棄されず、購読がpause状態で残ると
+  // Driftのclose()が完了しないため、この破棄が必須。
+  // 破棄時のクローズはapplyImportSwap内のクローズと
+  // closeAppDatabaseSafelyにより単一実行化される。
+  final oldDb = ref.read(appDatabaseProvider);
+  ref.invalidate(appDatabaseProvider);
+
+  Object? error;
+  try {
+    await BackupService(oldDb).applyImportSwap(payload.pendingFilePath);
+  } on Object catch (e) {
+    error = e;
+  }
+
+  // 新しいDBインスタンスをビルドの外で生成しておく。
+  // MyAppの再ビルド中に遅延再生成とその通知が走ると
+  // 「setState during build」になるため(実測で確認)。
+  // 生成だけではファイルは開かれず、実際のオープンは
+  // databaseInitializationProvider経由で行われる。
+  ref.read(appDatabaseProvider);
+
+  // Idleへ戻すとMyAppがdatabaseInitializationProviderを再監視し、
+  // 新しいDBインスタンスで開き直される(起動時と同一の再初期化経路)。
+  // 失敗時はapplyImportSwap内で元のファイルに復元済み。
+  // ビルド中の状態更新(setState during build)を避けるため、
+  // フレーム完了後に結果をセットする。
+  SchedulerBinding.instance.addPostFrameCallback((_) {
+    finishImportSwap(
+      ref,
+      result: error == null
+          ? const ImportSwapResult(success: true)
+          : ImportSwapResult(success: false, error: error.toString()),
+    );
+  });
 }
 
 /// DBを停止して行う保守操作の実行中に、
@@ -115,6 +207,15 @@ class DatabaseMaintenanceOverlay extends ConsumerWidget {
     if (maintenance is! DatabaseMaintenanceBusy) {
       return child;
     }
+    if (maintenance.importSwap != null) {
+      // DBファイルを置き換える間は配下の画面をアンマウントし、
+      // DBへのストリーム購読を全てキャンセルさせる。
+      // pause状態の購読が残っているとDriftのclose()が完了しないため、
+      // 子を含めずブロッキング画面のみを返す。
+      return DatabaseMaintenanceScreen(
+        operationLabel: maintenance.operationLabel,
+      );
+    }
     return Stack(
       children: [
         child,
@@ -125,6 +226,60 @@ class DatabaseMaintenanceOverlay extends ConsumerWidget {
         ),
       ],
     );
+  }
+}
+
+/// インポート適用の結果を検知してスナックバーで通知するウィジェット。
+///
+/// 適用処理は画面全体のアンマウントを伴うため、結果の通知は
+/// 再初期化後の画面ツリーで行う必要がある。マウント時に未消費の結果を
+/// 拾い、マウント中の変更も監視して一度だけ表示して消費する。
+class ImportSwapResultHandler extends ConsumerStatefulWidget {
+  /// コンストラクタ。
+  const ImportSwapResultHandler({required this.child, super.key});
+
+  /// 配下に表示する画面。
+  final Widget child;
+
+  @override
+  ConsumerState<ImportSwapResultHandler> createState() =>
+      _ImportSwapResultHandlerState();
+}
+
+class _ImportSwapResultHandlerState
+    extends ConsumerState<ImportSwapResultHandler> {
+  @override
+  void initState() {
+    super.initState();
+    // 再初期化の完了前に確定していた結果を拾う
+    WidgetsBinding.instance.addPostFrameCallback((_) => _consumeResult());
+  }
+
+  void _consumeResult() {
+    if (!mounted) return;
+    final result = ref.read(importSwapResultProvider);
+    if (result == null) return;
+    ref.read(importSwapResultProvider.notifier).state = null;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          result.success
+              ? 'データベースの復元が完了しました'
+              : 'データベースの復元に失敗しました。'
+                    '元のデータに復元済みです: ${result.error}',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<ImportSwapResult?>(importSwapResultProvider, (previous, next) {
+      if (next != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => _consumeResult());
+      }
+    });
+    return widget.child;
   }
 }
 
@@ -165,8 +320,10 @@ class _AppWithSettings extends ConsumerWidget {
               fontFamily: appUiFontFamily,
             ),
             routerConfig: router,
-            builder: (context, child) => DatabaseMaintenanceOverlay(
-              child: OfflineModeBanner(child: child!),
+            builder: (context, child) => ImportSwapResultHandler(
+              child: DatabaseMaintenanceOverlay(
+                child: OfflineModeBanner(child: child!),
+              ),
             ),
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:novelty/database/database.dart';
+import 'package:novelty/database/database_initialization.dart';
+import 'package:novelty/database/database_maintenance.dart';
 import 'package:novelty/router/router.dart';
+import 'package:novelty/screens/database_maintenance_screen.dart';
 import 'package:novelty/screens/migration_progress_splash.dart';
 import 'package:novelty/screens/migration_recovery_screen.dart';
 import 'package:novelty/services/backup_service.dart';
 import 'package:novelty/utils/font_family.dart';
 import 'package:novelty/utils/settings_provider.dart';
 import 'package:novelty/widgets/offline_mode_banner.dart';
-import 'package:riverpod/legacy.dart' show StateProvider;
+
+export 'package:novelty/database/database_initialization.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,20 +44,6 @@ const appLocalizationsDelegates = <LocalizationsDelegate<dynamic>>[
   GlobalCupertinoLocalizations.delegate,
 ];
 
-/// マイグレーションリトライ回数を管理するプロバイダー。
-final StateProvider<int> migrationRetryCounterProvider = StateProvider<int>(
-  (ref) => 0,
-);
-
-/// データベースの初期化（マイグレーション含む）を管理する FutureProvider。
-final FutureProvider<AppDatabase> databaseInitializationProvider =
-    FutureProvider<AppDatabase>((ref) async {
-      ref.watch(migrationRetryCounterProvider);
-      final db = ref.watch(appDatabaseProvider);
-      await db.doWhenOpened((_) async {});
-      return db;
-    });
-
 /// アプリケーションのエントリーポイント。
 /// データベースの初期化状態に応じて、進捗スプラッシュ、リカバリー画面、
 /// または通常のメイン画面を表示する。
@@ -72,7 +62,9 @@ class MyApp extends ConsumerWidget {
         supportedLocales: appSupportedLocales,
         localizationsDelegates: appLocalizationsDelegates,
         theme: ThemeData(fontFamily: appUiFontFamily),
-        home: const MigrationProgressSplash(),
+        home: const DatabaseMaintenanceOverlay(
+          child: MigrationProgressSplash(),
+        ),
       ),
       error: (err, stack) {
         final db = ref.read(appDatabaseProvider);
@@ -81,18 +73,57 @@ class MyApp extends ConsumerWidget {
           supportedLocales: appSupportedLocales,
           localizationsDelegates: appLocalizationsDelegates,
           theme: ThemeData(fontFamily: appUiFontFamily),
-          home: MigrationRecoveryScreen(
-            error: err,
-            onRetry: () {
-              ref.invalidate(appDatabaseProvider);
-              ref.read(migrationRetryCounterProvider.notifier).state++;
-            },
-            onExportDatabase: () async {
-              await BackupService(db).exportDatabaseToFile();
-            },
+          home: DatabaseMaintenanceOverlay(
+            child: MigrationRecoveryScreen(
+              error: err,
+              onRetry: () {
+                ref.invalidate(appDatabaseProvider);
+                ref.read(migrationRetryCounterProvider.notifier).state++;
+              },
+              onExportDatabase: () {
+                return runWithDatabaseMaintenance(
+                  ref,
+                  label: 'データベースをエクスポートしています…',
+                  task: () => BackupService(db).exportDatabaseToFile(),
+                );
+              },
+            ),
           ),
         );
       },
+    );
+  }
+}
+
+/// DBを停止して行う保守操作の実行中に、
+/// 配下の画面全体をブロッキング画面で覆うオーバーレイ。
+///
+/// [DatabaseMaintenanceBusy] の間は不透明なブロッキング画面を最前面に重ね、
+/// 配下のUIへのタッチを物理的に遮断する。
+/// 配下の画面は破棄されずに保持されるため、操作完了後の
+/// フィードバック(ダイアログ等)をそのまま表示できる。
+class DatabaseMaintenanceOverlay extends ConsumerWidget {
+  /// コンストラクタ。
+  const DatabaseMaintenanceOverlay({required this.child, super.key});
+
+  /// 配下に表示する画面。
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final maintenance = ref.watch(databaseMaintenanceProvider);
+    if (maintenance is! DatabaseMaintenanceBusy) {
+      return child;
+    }
+    return Stack(
+      children: [
+        child,
+        Positioned.fill(
+          child: DatabaseMaintenanceScreen(
+            operationLabel: maintenance.operationLabel,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -134,7 +165,9 @@ class _AppWithSettings extends ConsumerWidget {
               fontFamily: appUiFontFamily,
             ),
             routerConfig: router,
-            builder: (context, child) => OfflineModeBanner(child: child!),
+            builder: (context, child) => DatabaseMaintenanceOverlay(
+              child: OfflineModeBanner(child: child!),
+            ),
           );
         },
       ),

--- a/lib/screens/data_storage_page.dart
+++ b/lib/screens/data_storage_page.dart
@@ -21,14 +21,11 @@ class DataStoragePage extends ConsumerStatefulWidget {
 }
 
 class _DataStoragePageState extends ConsumerState<DataStoragePage> {
-  late BackupService _backupService;
-
-  @override
-  void initState() {
-    super.initState();
-    _backupService =
-        widget.backupService ?? BackupService(ref.read(appDatabaseProvider));
-  }
+  /// バックアップサービス。
+  /// インポートでDBインスタンスが差し替わるため、
+  /// 使用のたびに現在のプロバイダーから生成する。
+  BackupService get _backupService =>
+      widget.backupService ?? BackupService(ref.read(appDatabaseProvider));
 
   @override
   Widget build(BuildContext context) {
@@ -102,7 +99,7 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
     if (!mounted) return;
 
     if (error != null) {
-      _showErrorDialog('エクスポートに失敗しました', error.toString());
+      unawaited(_showErrorDialog('エクスポートに失敗しました', error.toString()));
       return;
     }
     if (filePath == null) {
@@ -110,13 +107,12 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
       return;
     }
 
-    // 完了を明示してからデータベースを再初期化する
+    // VACUUM INTO は接続を維持したまま整合性のあるコピーを取得
+    // できるため、エクスポート後のデータベース再初期化は不要。
     await _showSuccessDialog(
       'データベースのエクスポートが完了しました',
       'バックアップファイルを保存しました:\n$filePath',
     );
-    if (!mounted) return;
-    ref.invalidate(appDatabaseProvider);
   }
 
   /// ストレージ設定セクションを構築
@@ -186,7 +182,7 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
       }
     } on Exception catch (e) {
       if (mounted) {
-        _showErrorDialog('エラー', 'キャッシュの削除に失敗しました: $e');
+        unawaited(_showErrorDialog('エラー', 'キャッシュの削除に失敗しました: $e'));
       }
     }
   }
@@ -199,13 +195,15 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
       return;
     }
 
-    ImportResult? result;
+    // ステージング(バックアップファイルの読み込み)。
+    // この段階ではDB接続もDBファイルも変更されない。
+    ImportStagedResult? staged;
     Object? error;
     try {
-      result = await runWithDatabaseMaintenance(
+      staged = await runWithDatabaseMaintenance(
         ref,
-        label: 'データベースをインポートしています…',
-        task: _backupService.importDatabaseFromFile,
+        label: 'バックアップファイルを読み込んでいます…',
+        task: _backupService.stageImport,
       );
     } on Object catch (e) {
       error = e;
@@ -214,24 +212,25 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
     if (!mounted) return;
 
     if (error != null) {
-      _showErrorDialog('インポートに失敗しました', error.toString());
+      unawaited(_showErrorDialog('インポートに失敗しました', error.toString()));
       return;
     }
-    if (result == null || result.cancelled) {
+    if (staged == null || staged.cancelled) {
       _showSnackBar('インポートをキャンセルしました');
       return;
     }
-    if (!result.success) {
-      _showErrorDialog('インポートに失敗しました', '不明なエラーが発生しました');
-      return;
-    }
 
-    // 完了を明示してからデータベースを再初期化する。
-    // 再初期化は起動時と同一の経路(進捗スプラッシュ表示)で行われ、
-    // 古いバージョンのバックアップは自動的にマイグレーションされる。
-    await _showSuccessDialog('復元が完了しました', 'すべてのデータが復元されました。');
-    if (!mounted) return;
-    ref.invalidate(appDatabaseProvider);
+    // 読み込みが完了したので、データベースを切り替える。
+    // 切り替え中は画面全体がアンマウントされて再初期化されるため、
+    // 結果は再初期化後にスナックバーで通知される
+    // (importSwapResultProvider 経由)。
+    startImportSwap(
+      ref,
+      payload: ImportSwapPayload(
+        pendingFilePath: staged.pendingFilePath!,
+        backupVersion: staged.backupVersion,
+      ),
+    );
   }
 
   /// インポート確認ダイアログを表示
@@ -284,20 +283,18 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
   }
 
   /// エラーダイアログを表示
-  void _showErrorDialog(String title, String message) {
-    unawaited(
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text(title),
-          content: Text(message),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
+  Future<void> _showErrorDialog(String title, String message) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/data_storage_page.dart
+++ b/lib/screens/data_storage_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:novelty/database/database.dart';
+import 'package:novelty/database/database_maintenance.dart';
 import 'package:novelty/services/backup_service.dart';
 import 'package:novelty/utils/settings_provider.dart';
 
@@ -21,7 +22,6 @@ class DataStoragePage extends ConsumerStatefulWidget {
 
 class _DataStoragePageState extends ConsumerState<DataStoragePage> {
   late BackupService _backupService;
-  bool _isProcessing = false;
 
   @override
   void initState() {
@@ -73,14 +73,12 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
           leading: const Icon(Icons.save_alt),
           title: const Text('データベースをエクスポート'),
           subtitle: const Text('すべてのデータをバックアップファイルに保存'),
-          enabled: !_isProcessing,
           onTap: _exportDatabase,
         ),
         ListTile(
           leading: const Icon(Icons.upload_file),
           title: const Text('データベースをインポート'),
           subtitle: const Text('バックアップファイルからすべてのデータを復元'),
-          enabled: !_isProcessing,
           onTap: _importDatabase,
         ),
       ],
@@ -89,32 +87,36 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
 
   /// データベース全体をエクスポート
   Future<void> _exportDatabase() async {
-    setState(() {
-      _isProcessing = true;
-    });
-
+    String? filePath;
+    Object? error;
     try {
-      final filePath = await _backupService.exportDatabaseToFile();
-      if (filePath != null && mounted) {
-        // データベースプロバイダーを再初期化
-        ref.invalidate(appDatabaseProvider);
-
-        _showSuccessDialog(
-          'データベースのエクスポートが完了しました',
-          'バックアップファイルを保存しました:\n$filePath',
-        );
-      }
-    } on Exception catch (e) {
-      if (mounted) {
-        _showErrorDialog('エクスポートに失敗しました', e.toString());
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
-      }
+      filePath = await runWithDatabaseMaintenance(
+        ref,
+        label: 'データベースをエクスポートしています…',
+        task: _backupService.exportDatabaseToFile,
+      );
+    } on Object catch (e) {
+      error = e;
     }
+
+    if (!mounted) return;
+
+    if (error != null) {
+      _showErrorDialog('エクスポートに失敗しました', error.toString());
+      return;
+    }
+    if (filePath == null) {
+      _showSnackBar('エクスポートをキャンセルしました');
+      return;
+    }
+
+    // 完了を明示してからデータベースを再初期化する
+    await _showSuccessDialog(
+      'データベースのエクスポートが完了しました',
+      'バックアップファイルを保存しました:\n$filePath',
+    );
+    if (!mounted) return;
+    ref.invalidate(appDatabaseProvider);
   }
 
   /// ストレージ設定セクションを構築
@@ -174,27 +176,17 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
 
     if (confirmed != true) return;
 
-    setState(() {
-      _isProcessing = true;
-    });
-
     try {
       // TODO(L4Ph): Implement actual cache clearing logic here
       // For now, we simulate a delay
       await Future<void>.delayed(const Duration(seconds: 1));
 
       if (mounted) {
-        _showSuccessDialog('完了', 'キャッシュを削除しました');
+        unawaited(_showSuccessDialog('完了', 'キャッシュを削除しました'));
       }
     } on Exception catch (e) {
       if (mounted) {
         _showErrorDialog('エラー', 'キャッシュの削除に失敗しました: $e');
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
       }
     }
   }
@@ -207,33 +199,39 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
       return;
     }
 
-    setState(() {
-      _isProcessing = true;
-    });
-
+    ImportResult? result;
+    Object? error;
     try {
-      final result = await _backupService.importDatabaseFromFile();
-      if (result.success && mounted) {
-        // データベースプロバイダーを再初期化
-        ref.invalidate(appDatabaseProvider);
-
-        // マイグレーション情報を含めて再起動ダイアログを表示
-        _showRestartRequiredDialog(
-          requiresMigration: result.requiresMigration,
-          backupVersion: result.backupVersion,
-        );
-      }
-    } on Exception catch (e) {
-      if (mounted) {
-        _showErrorDialog('インポートに失敗しました', e.toString());
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
-      }
+      result = await runWithDatabaseMaintenance(
+        ref,
+        label: 'データベースをインポートしています…',
+        task: _backupService.importDatabaseFromFile,
+      );
+    } on Object catch (e) {
+      error = e;
     }
+
+    if (!mounted) return;
+
+    if (error != null) {
+      _showErrorDialog('インポートに失敗しました', error.toString());
+      return;
+    }
+    if (result == null || result.cancelled) {
+      _showSnackBar('インポートをキャンセルしました');
+      return;
+    }
+    if (!result.success) {
+      _showErrorDialog('インポートに失敗しました', '不明なエラーが発生しました');
+      return;
+    }
+
+    // 完了を明示してからデータベースを再初期化する。
+    // 再初期化は起動時と同一の経路(進捗スプラッシュ表示)で行われ、
+    // 古いバージョンのバックアップは自動的にマイグレーションされる。
+    await _showSuccessDialog('復元が完了しました', 'すべてのデータが復元されました。');
+    if (!mounted) return;
+    ref.invalidate(appDatabaseProvider);
   }
 
   /// インポート確認ダイアログを表示
@@ -262,21 +260,26 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
   }
 
   /// 成功ダイアログを表示
-  void _showSuccessDialog(String title, String message) {
-    unawaited(
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text(title),
-          content: Text(message),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
+  Future<void> _showSuccessDialog(String title, String message) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
       ),
+    );
+  }
+
+  /// スナックバーを表示
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 
@@ -291,42 +294,6 @@ class _DataStoragePageState extends ConsumerState<DataStoragePage> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// 再起動が必要なことを通知するダイアログを表示
-  void _showRestartRequiredDialog({
-    bool requiresMigration = false,
-    int? backupVersion,
-  }) {
-    // メッセージを構築
-    var message = 'すべてのデータが復元されました。\n\n';
-
-    if (requiresMigration && backupVersion != null) {
-      message +=
-          '※ このバックアップは古いバージョン(v$backupVersion)のものです。\n'
-          'アプリ起動時に自動的に最新バージョンへ移行されます。\n\n';
-    }
-
-    message += '変更を反映するため、アプリを終了して再起動してください。';
-
-    unawaited(
-      showDialog<void>(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) => AlertDialog(
-          title: const Text('復元が完了しました'),
-          content: Text(message),
-          actions: [
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
               child: const Text('OK'),
             ),
           ],

--- a/lib/screens/database_maintenance_screen.dart
+++ b/lib/screens/database_maintenance_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// DBを停止して行う保守操作(インポート/エクスポート)の実行中に、
+/// アプリ全体を覆って表示するブロッキング画面。
+///
+/// 長時間かかる処理中にユーザーが誤って操作を続けないよう、
+/// 実行中の操作名を明示する。
+class DatabaseMaintenanceScreen extends StatelessWidget {
+  /// コンストラクタ
+  const DatabaseMaintenanceScreen({required this.operationLabel, super.key});
+
+  /// ユーザー向けの操作説明(例: 「データベースをインポートしています…」)
+  final String operationLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(height: 24),
+              Text(
+                operationLabel,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                '時間がかかる場合がありますが、画面を閉じずにお待ちください。',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/migration_recovery_screen.dart
+++ b/lib/screens/migration_recovery_screen.dart
@@ -22,8 +22,9 @@ class MigrationRecoveryScreen extends StatelessWidget {
   /// リトライボタンが押されたときに呼ばれるコールバック
   final VoidCallback? onRetry;
 
-  /// DBエクスポートボタンが押されたときに呼ばれるコールバック
-  final Future<void> Function()? onExportDatabase;
+  /// DBエクスポートボタンが押されたときに呼ばれるコールバック。
+  /// 戻り値はエクスポートされたファイルのパス。キャンセル時はnull。
+  final Future<String?> Function()? onExportDatabase;
 
   @override
   Widget build(BuildContext context) {
@@ -105,11 +106,43 @@ class MigrationRecoveryScreen extends StatelessWidget {
       return;
     }
     try {
-      await onExportDatabase!();
-    } on Exception catch (e) {
-      if (context.mounted) {
+      final exportPath = await onExportDatabase!();
+      if (!context.mounted) {
+        return;
+      }
+      if (exportPath == null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エクスポートに失敗しました: $e')),
+          const SnackBar(content: Text('エクスポートをキャンセルしました')),
+        );
+      } else {
+        await showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('データベースのエクスポートが完了しました'),
+            content: Text('バックアップファイルを保存しました:\n$exportPath'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+    } on Object catch (e) {
+      if (context.mounted) {
+        await showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('エクスポートに失敗しました'),
+            content: Text(e.toString()),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
         );
       }
     }

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -64,40 +64,58 @@ class BackupService {
   /// バックアップファイルからデータベース全体を復元する
   /// 既存のデータベースは上書きされる
   ///
-  /// 戻り値: インポート結果
+  /// 戻り値: インポート結果(キャンセル時は [ImportResult.cancelled] がtrue)
+  ///
+  /// 失敗時は例外をスローし、元のデータベースファイルを復元する。
   Future<ImportResult> importDatabaseFromFile() async {
     // バックアップファイルを選択
+    // AndroidのSAF経由では PlatformFile.path がnull(content:// URI)に
+    // なり得るため、readStream経由で読み込む
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['db'],
       dialogTitle: 'バックアップファイルを選択',
+      withReadStream: true,
     );
 
     if (result == null || result.files.isEmpty) {
-      return const ImportResult(success: false);
+      return const ImportResult(cancelled: true);
     }
 
+    final pickedFile = result.files.single;
+
     // ファイル名からスキーマバージョンを抽出
-    final fileName = result.files.single.name;
-    final backupVersion = _extractVersionFromFileName(fileName);
+    final backupVersion = _extractVersionFromFileName(pickedFile.name);
+
+    final readStream = pickedFile.readStream;
+    if (readStream == null) {
+      throw StateError('選択したファイルを読み込めませんでした');
+    }
 
     // データベース接続を閉じる
     await _database.close();
 
-    try {
-      // データベースファイルのパスを取得
-      final dbFolder = await getApplicationDocumentsDirectory();
-      final dbFile = File(p.join(dbFolder.path, 'novelty.db'));
+    // データベースファイルのパスを取得
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final dbFile = File(p.join(dbFolder.path, 'novelty.db'));
+    final backupFile = File('${dbFile.path}.bak');
 
+    var backupCreated = false;
+    try {
       // 既存のデータベースをバックアップ(念のため)
       if (dbFile.existsSync()) {
-        final backupFile = File('${dbFile.path}.bak');
         await dbFile.copy(backupFile.path);
+        backupCreated = true;
       }
 
-      // 選択したバックアップファイルで置き換え
-      final selectedFile = File(result.files.single.path!);
-      await selectedFile.copy(dbFile.path);
+      // 選択したバックアップファイルの内容で置き換え
+      final sink = dbFile.openWrite();
+      try {
+        await sink.addStream(readStream);
+        await sink.flush();
+      } finally {
+        await sink.close();
+      }
 
       return ImportResult(
         success: true,
@@ -105,9 +123,12 @@ class BackupService {
         requiresMigration:
             backupVersion != null && backupVersion < currentSchemaVersion,
       );
-    } finally {
-      // データベースを再初期化するため、何もしない
-      // 呼び出し側でプロバイダーをinvalidateする必要がある
+    } on Object {
+      // コピー失敗時は元のデータベースファイルを復元する
+      if (backupCreated && backupFile.existsSync()) {
+        await backupFile.copy(dbFile.path);
+      }
+      rethrow;
     }
   }
 
@@ -140,13 +161,17 @@ class BackupService {
 class ImportResult {
   /// コンストラクタ
   const ImportResult({
-    required this.success,
+    this.success = false,
+    this.cancelled = false,
     this.backupVersion,
     this.requiresMigration = false,
   });
 
   /// インポートが成功したかどうか
   final bool success;
+
+  /// ファイル選択がキャンセルされたかどうか
+  final bool cancelled;
 
   /// バックアップファイルのスキーマバージョン
   final int? backupVersion;

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
@@ -25,6 +26,10 @@ class BackupService {
   /// 含むデータベースファイルをバックアップする
   ///
   /// 戻り値: エクスポートされたファイルのパス。キャンセルされた場合はnull
+  ///
+  /// SQLiteの `VACUUM INTO` を使い、DBを閉じずに整合性のある
+  /// コピーを取得する(DBクローズはアクティブなストリームを
+  /// 待機して完了しないことがあるため、クリティカルパスから外す)。
   Future<String?> exportDatabaseToFile() async {
     // 保存先ディレクトリを選択
     final selectedDirectory = await FilePicker.platform.getDirectoryPath(
@@ -35,51 +40,79 @@ class BackupService {
       return null;
     }
 
-    // データベース接続を閉じる
-    await _database.close();
+    // バックアップファイル名を生成(スキーマバージョンを含める)
+    final fileName =
+        'novelty_backup_${_formatDateTime(DateTime.now())}'
+        '_v$currentSchemaVersion.db';
+    final backupPath = p.join(selectedDirectory, fileName);
 
-    try {
-      // データベースファイルのパスを取得
-      final dbFolder = await getApplicationDocumentsDirectory();
-      final dbFile = File(p.join(dbFolder.path, 'novelty.db'));
+    // VACUUM INTO で整合性のあるバックアップを作成
+    final escapedPath = backupPath.replaceAll("'", "''");
+    await _database.customStatement("VACUUM INTO '$escapedPath'");
 
-      // バックアップファイル名を生成(スキーマバージョンを含める)
-      final fileName =
-          'novelty_backup_${_formatDateTime(DateTime.now())}'
-          '_v$currentSchemaVersion.db';
-      final backupPath = p.join(selectedDirectory, fileName);
-
-      // データベースファイルをコピー
-      await dbFile.copy(backupPath);
-
-      return backupPath;
-    } finally {
-      // データベースを再初期化するため、何もしない
-      // 呼び出し側でプロバイダーをinvalidateする必要がある
-    }
+    return backupPath;
   }
 
-  /// データベース全体をインポートする
+  /// データベースファイルを直接コピーしてエクスポートする
   ///
-  /// バックアップファイルからデータベース全体を復元する
-  /// 既存のデータベースは上書きされる
+  /// マイグレーション失敗時など、DBが開けない状態でもファイルとして
+  /// コピーできることが利点。リカバリ画面からのエクスポートに使用する。
+  /// (DBを開けている通常経路では [exportDatabaseToFile] を使うこと)
   ///
-  /// 戻り値: インポート結果(キャンセル時は [ImportResult.cancelled] がtrue)
+  /// 戻り値: エクスポートされたファイルのパス。キャンセルされた場合はnull
+  Future<String?> exportDatabaseFileDirectly() async {
+    final selectedDirectory = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'バックアップ先のディレクトリを選択',
+    );
+
+    if (selectedDirectory == null) {
+      return null;
+    }
+
+    // 開いているDBをクローズしてからコピーする(WALの内容を
+    // 本体に反映させるため)。マイグレーション失敗直後など接続が
+    // 不安定な状態でもコピーは試行する(ベストエフォート)。
+    try {
+      await _database.close();
+    } on Object {
+      // クローズに失敗してもコピーは継続する
+    }
+
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final dbFile = File(p.join(dbFolder.path, 'novelty.db'));
+
+    final fileName =
+        'novelty_backup_${_formatDateTime(DateTime.now())}'
+        '_v$currentSchemaVersion.db';
+    final backupPath = p.join(selectedDirectory, fileName);
+
+    await dbFile.copy(backupPath);
+
+    return backupPath;
+  }
+
+  /// インポートのステージング(バックアップファイルの読み込み)
   ///
-  /// 失敗時は例外をスローし、元のデータベースファイルを復元する。
-  Future<ImportResult> importDatabaseFromFile() async {
-    // バックアップファイルを選択
-    // AndroidのSAF経由では PlatformFile.path がnull(content:// URI)に
-    // なり得るため、readStream経由で読み込む
+  /// 選択したバックアップファイルをアプリ内の一時ファイル
+  /// (`novelty.db.import_pending`)にコピーする。
+  /// この段階ではDB接続も既存のDBファイルも変更しない。
+  ///
+  /// 戻り値: ステージング結果(キャンセル時は
+  /// [ImportStagedResult.cancelled] がtrue)
+  ///
+  /// 成功後は [applyImportSwap] でファイルを置き換えること。
+  Future<ImportStagedResult> stageImport() async {
+    // バックアップファイルを選択。
+    // 選択されたファイルはFilePickerがアプリのキャッシュにコピーし、
+    // 実パスを返してくれる(AndroidのSAF経由でも同様)。
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['db'],
       dialogTitle: 'バックアップファイルを選択',
-      withReadStream: true,
     );
 
     if (result == null || result.files.isEmpty) {
-      return const ImportResult(cancelled: true);
+      return const ImportStagedResult(cancelled: true);
     }
 
     final pickedFile = result.files.single;
@@ -87,46 +120,107 @@ class BackupService {
     // ファイル名からスキーマバージョンを抽出
     final backupVersion = _extractVersionFromFileName(pickedFile.name);
 
-    final readStream = pickedFile.readStream;
-    if (readStream == null) {
+    final pickedPath = pickedFile.path;
+    if (pickedPath == null) {
       throw StateError('選択したファイルを読み込めませんでした');
     }
 
-    // データベース接続を閉じる
-    await _database.close();
+    // ステージング先(前回の残骸があれば消してから書き込む)
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final pendingFile = File(
+      p.join(dbFolder.path, 'novelty.db.import_pending'),
+    );
+    if (pendingFile.existsSync()) {
+      await pendingFile.delete();
+    }
 
-    // データベースファイルのパスを取得
+    try {
+      await File(pickedPath).copy(pendingFile.path);
+    } on Object {
+      // 書き込み途中のファイルを残さない
+      if (pendingFile.existsSync()) {
+        await pendingFile.delete();
+      }
+      rethrow;
+    }
+
+    // FilePickerのキャッシュは自動削除されず繰り返すと
+    // ストレージを圧迫するため、コピー後に消去する
+    await _clearFilePickerCache();
+
+    return ImportStagedResult(
+      pendingFilePath: pendingFile.path,
+      backupVersion: backupVersion,
+    );
+  }
+
+  /// FilePickerの一時キャッシュを消去する(失敗しても続行する)
+  Future<void> _clearFilePickerCache() async {
+    try {
+      await FilePicker.platform.clearTemporaryFiles();
+    } on Object {
+      // 消去に失敗しても続行する
+    }
+  }
+
+  /// ステージング済みのファイルでデータベースを置き換える
+  ///
+  /// 既存のDBファイルを `.bak` に退避したうえで、DB接続をクローズし、
+  /// ステージング済みファイルにリネームで置き換える。
+  /// 失敗時は `.bak` から元のDBファイルを復元して例外をスローする。
+  /// いずれの場合も、呼び出し側でプロバイダーを再初期化して
+  /// データベースを開き直すこと。
+  ///
+  /// 注意: 呼び出し前に `appDatabaseProvider` をinvalidateして
+  /// DB依存プロバイダを全て破棄(ストリーム購読をキャンセル)しておくこと。
+  /// 購読がpause状態で残っているとDriftのclose()は完了しない
+  /// (実測で確認済み)。
+  Future<void> applyImportSwap(String pendingFilePath) async {
     final dbFolder = await getApplicationDocumentsDirectory();
     final dbFile = File(p.join(dbFolder.path, 'novelty.db'));
     final backupFile = File('${dbFile.path}.bak');
+    final pendingFile = File(pendingFilePath);
 
-    var backupCreated = false;
+    if (!pendingFile.existsSync()) {
+      throw StateError('ステージング済みファイルが見つかりません: ${pendingFile.path}');
+    }
+
+    // 既存のデータベースをバックアップ(復元用)
+    if (dbFile.existsSync()) {
+      await dbFile.copy(backupFile.path);
+    }
+
+    var renamed = false;
     try {
-      // 既存のデータベースをバックアップ(念のため)
-      if (dbFile.existsSync()) {
-        await dbFile.copy(backupFile.path);
-        backupCreated = true;
-      }
-
-      // 選択したバックアップファイルの内容で置き換え
-      final sink = dbFile.openWrite();
-      try {
-        await sink.addStream(readStream);
-        await sink.flush();
-      } finally {
-        await sink.close();
-      }
-
-      return ImportResult(
-        success: true,
-        backupVersion: backupVersion,
-        requiresMigration:
-            backupVersion != null && backupVersion < currentSchemaVersion,
+      // ファイルを置き換える前にDB接続をクローズする。
+      // Windowsでは開いているファイルをリネームできないため必須。
+      // プロバイダー破棄時のクローズと競合しないよう単一実行化し、
+      // 万が一完了しない場合に備えてタイムアウトを設ける。
+      await closeAppDatabaseSafely(_database).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => throw TimeoutException('データベースのクローズがタイムアウトしました'),
       );
+
+      // 置き換え前にジャーナル/WAL等のサイドカーファイルを削除する。
+      // 残存していると新しいDBファイルに旧データが復旧適用されてしまう。
+      for (final suffix in ['-journal', '-wal', '-shm']) {
+        final sidecar = File('${dbFile.path}$suffix');
+        if (sidecar.existsSync()) {
+          await sidecar.delete();
+        }
+      }
+
+      // リネームで原子的に置き換える
+      await pendingFile.rename(dbFile.path);
+      renamed = true;
     } on Object {
-      // コピー失敗時は元のデータベースファイルを復元する
-      if (backupCreated && backupFile.existsSync()) {
+      // 失敗時は元のデータベースファイルを復元し、
+      // ステージング済みファイルを破棄する
+      if (!renamed && backupFile.existsSync()) {
         await backupFile.copy(dbFile.path);
+      }
+      if (pendingFile.existsSync()) {
+        await pendingFile.delete();
       }
       rethrow;
     }
@@ -157,25 +251,21 @@ class BackupService {
   }
 }
 
-/// データベースインポートの結果
-class ImportResult {
+/// インポートのステージング結果
+class ImportStagedResult {
   /// コンストラクタ
-  const ImportResult({
-    this.success = false,
+  const ImportStagedResult({
     this.cancelled = false,
+    this.pendingFilePath,
     this.backupVersion,
-    this.requiresMigration = false,
   });
-
-  /// インポートが成功したかどうか
-  final bool success;
 
   /// ファイル選択がキャンセルされたかどうか
   final bool cancelled;
 
+  /// ステージング済みファイルのパス(キャンセル時はnull)
+  final String? pendingFilePath;
+
   /// バックアップファイルのスキーマバージョン
   final int? backupVersion;
-
-  /// マイグレーションが必要かどうか
-  final bool requiresMigration;
 }

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:novelty/database/database.dart';
+import 'package:novelty/database/database_maintenance.dart';
+import 'package:novelty/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// DBを停止して行う保守操作(import/export)中に、
+/// アプリ全体がブロッキング画面で覆われることを検証する。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<ProviderContainer> pumpMyApp(
+    WidgetTester tester, {
+    required Future<AppDatabase> Function() dbInit,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          databaseInitializationProvider.overrideWith((ref) => dbInit()),
+        ],
+        child: const MyApp(),
+      ),
+    );
+    return ProviderScope.containerOf(tester.element(find.byType(MyApp)));
+  }
+
+  group('データベースメンテナンスのブロッキング', () {
+    testWidgets('Busy状態ではDB初期化中でもブロッキング画面が表示される', (
+      tester,
+    ) async {
+      final container = await pumpMyApp(
+        tester,
+        dbInit: () => Completer<AppDatabase>().future,
+      );
+
+      container.read(databaseMaintenanceProvider.notifier).state =
+          const DatabaseMaintenanceBusy('データベースをインポートしています…');
+      await tester.pump();
+
+      expect(find.text('データベースをインポートしています…'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+    });
+
+    testWidgets('Busy状態ではオーバーレイが配下の画面を覆い、操作を遮断する', (
+      tester,
+    ) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: DatabaseMaintenanceOverlay(
+              child: Scaffold(
+                body: Center(
+                  child: TextButton(
+                    onPressed: () => tapped++,
+                    child: const Text('配下のボタン'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DatabaseMaintenanceOverlay)),
+      );
+
+      container.read(databaseMaintenanceProvider.notifier).state =
+          const DatabaseMaintenanceBusy('データベースをエクスポートしています…');
+      await tester.pump();
+
+      // ブロッキング画面が表示され、配下の画面は破棄されずに維持される
+      expect(find.text('データベースをエクスポートしています…'), findsOneWidget);
+      expect(find.text('配下のボタン'), findsOneWidget);
+
+      // 配下のボタン位置をタップしても、ブロッキング画面に遮断される
+      await tester.tap(find.text('配下のボタン'), warnIfMissed: false);
+      await tester.pump();
+      expect(tapped, 0);
+
+      // Idleに戻すと配下が再び操作できる
+      container.read(databaseMaintenanceProvider.notifier).state =
+          const DatabaseMaintenanceIdle();
+      await tester.pump();
+      expect(find.text('データベースをエクスポートしています…'), findsNothing);
+      await tester.tap(find.text('配下のボタン'));
+      await tester.pump();
+      expect(tapped, 1);
+    });
+
+    testWidgets('Idle状態ではブロッキング画面は表示されない', (tester) async {
+      await pumpMyApp(
+        tester,
+        dbInit: () => Completer<AppDatabase>().future,
+      );
+      await tester.pump();
+
+      // ブロッキング画面ではなく、通常のマイグレーションスプラッシュが表示される
+      expect(find.text('データベースをインポートしています…'), findsNothing);
+      expect(find.text('読書データを最新の状態に更新しています。'), findsOneWidget);
+    });
+  });
+}

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -104,5 +104,40 @@ void main() {
       expect(find.text('データベースをインポートしています…'), findsNothing);
       expect(find.text('読書データを最新の状態に更新しています。'), findsOneWidget);
     });
+
+    testWidgets('インポート適用中は配下の画面がアンマウントされる', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: DatabaseMaintenanceOverlay(
+              child: Scaffold(body: Center(child: Text('配下の画面'))),
+            ),
+          ),
+        ),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DatabaseMaintenanceOverlay)),
+      );
+
+      // 通常のBusy状態では配下の画面は維持される
+      container.read(databaseMaintenanceProvider.notifier).state =
+          const DatabaseMaintenanceBusy('データベースをエクスポートしています…');
+      await tester.pump();
+      expect(find.text('配下の画面'), findsOneWidget);
+
+      // インポート適用(payload付き)では配下の画面がアンマウントされる。
+      // DBへのストリーム購読を全てキャンセルさせるため。
+      container
+          .read(databaseMaintenanceProvider.notifier)
+          .state = const DatabaseMaintenanceBusy(
+        'データベースを切り替えています…',
+        importSwap: ImportSwapPayload(
+          pendingFilePath: '/tmp/novelty.db.import_pending',
+        ),
+      );
+      await tester.pump();
+      expect(find.text('データベースを切り替えています…'), findsOneWidget);
+      expect(find.text('配下の画面'), findsNothing);
+    });
   });
 }

--- a/test/screens/data_storage_page_test.dart
+++ b/test/screens/data_storage_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:novelty/database/database.dart';
 import 'package:novelty/database/database_initialization.dart';
+import 'package:novelty/database/database_maintenance.dart';
 import 'package:novelty/screens/data_storage_page.dart';
 import 'package:novelty/services/backup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -93,8 +94,8 @@ void main() {
 
     group('インポート', () {
       testWidgets('データベースインポート確認ダイアログが表示される', (tester) async {
-        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
-          (_) async => const ImportResult(success: true),
+        when(mockBackupService.stageImport()).thenAnswer(
+          (_) async => const ImportStagedResult(cancelled: true),
         );
 
         await pumpPage(tester);
@@ -106,9 +107,14 @@ void main() {
         expect(find.text('復元する'), findsOneWidget);
       });
 
-      testWidgets('成功すると復元完了ダイアログが表示される', (tester) async {
-        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
-          (_) async => const ImportResult(success: true),
+      testWidgets('読み込みが成功するとデータベースの切り替えが開始される', (
+        tester,
+      ) async {
+        when(mockBackupService.stageImport()).thenAnswer(
+          (_) async => const ImportStagedResult(
+            pendingFilePath: '/tmp/novelty.db.import_pending',
+            backupVersion: 17,
+          ),
         );
 
         await pumpPage(tester);
@@ -117,13 +123,21 @@ void main() {
         await tester.tap(find.text('復元する'));
         await tester.pumpAndSettle();
 
-        expect(find.text('復元が完了しました'), findsOneWidget);
-        verify(mockBackupService.importDatabaseFromFile()).called(1);
+        verify(mockBackupService.stageImport()).called(1);
+
+        final element = tester.element(find.byType(DataStoragePage));
+        final container = ProviderScope.containerOf(element);
+        final maintenance = container.read(databaseMaintenanceProvider);
+        expect(maintenance, isA<DatabaseMaintenanceBusy>());
+        final swap = (maintenance as DatabaseMaintenanceBusy).importSwap;
+        expect(swap, isNotNull);
+        expect(swap!.pendingFilePath, '/tmp/novelty.db.import_pending');
+        expect(swap.backupVersion, 17);
       });
 
       testWidgets('キャンセルするとスナックバーが表示される', (tester) async {
-        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
-          (_) async => const ImportResult(cancelled: true),
+        when(mockBackupService.stageImport()).thenAnswer(
+          (_) async => const ImportStagedResult(cancelled: true),
         );
 
         await pumpPage(tester);
@@ -137,7 +151,7 @@ void main() {
 
       testWidgets('失敗すると理由付きのエラーダイアログが表示される', (tester) async {
         when(
-          mockBackupService.importDatabaseFromFile(),
+          mockBackupService.stageImport(),
         ).thenThrow(Exception('import boom'));
 
         await pumpPage(tester);

--- a/test/screens/data_storage_page_test.dart
+++ b/test/screens/data_storage_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:novelty/database/database.dart';
+import 'package:novelty/database/database_initialization.dart';
 import 'package:novelty/screens/data_storage_page.dart';
 import 'package:novelty/services/backup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,82 +22,133 @@ void main() {
       mockBackupService = MockBackupService();
     });
 
-    testWidgets('ページタイトルが正しく表示される', (tester) async {
+    Future<void> pumpPage(WidgetTester tester) async {
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            databaseInitializationProvider.overrideWith(
+              (ref) async => AppDatabase.memory(),
+            ),
+          ],
           child: MaterialApp(
             home: DataStoragePage(backupService: mockBackupService),
           ),
         ),
       );
+    }
+
+    testWidgets('ページタイトルが正しく表示される', (tester) async {
+      await pumpPage(tester);
 
       expect(find.text('データとストレージ'), findsOneWidget);
     });
 
     testWidgets('データベースバックアップセクションが表示される', (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DataStoragePage(backupService: mockBackupService),
-          ),
-        ),
-      );
+      await pumpPage(tester);
 
       expect(find.text('データベースのバックアップ'), findsOneWidget);
       expect(find.text('データベースをエクスポート'), findsOneWidget);
       expect(find.text('データベースをインポート'), findsOneWidget);
     });
 
-    testWidgets('データベースエクスポートボタンをタップできる', (tester) async {
-      when(mockBackupService.exportDatabaseToFile()).thenAnswer(
-        (_) async => '/test/path/novelty_backup.db',
-      );
+    group('エクスポート', () {
+      testWidgets('成功すると完了ダイアログが表示される', (tester) async {
+        when(mockBackupService.exportDatabaseToFile()).thenAnswer(
+          (_) async => '/test/path/novelty_backup.db',
+        );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DataStoragePage(backupService: mockBackupService),
-          ),
-        ),
-      );
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをエクスポート'));
+        await tester.pumpAndSettle();
 
-      await tester.pumpAndSettle();
+        expect(find.text('データベースのエクスポートが完了しました'), findsOneWidget);
+        verify(mockBackupService.exportDatabaseToFile()).called(1);
+      });
 
-      final exportButton = find.text('データベースをエクスポート');
-      expect(exportButton, findsOneWidget);
+      testWidgets('キャンセルするとスナックバーが表示される', (tester) async {
+        when(
+          mockBackupService.exportDatabaseToFile(),
+        ).thenAnswer((_) async => null);
 
-      await tester.tap(exportButton);
-      await tester.pumpAndSettle();
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをエクスポート'));
+        await tester.pumpAndSettle();
 
-      // バックアップサービスが呼び出されることを確認
-      verify(mockBackupService.exportDatabaseToFile()).called(1);
+        expect(find.text('エクスポートをキャンセルしました'), findsOneWidget);
+      });
+
+      testWidgets('失敗すると理由付きのエラーダイアログが表示される', (tester) async {
+        when(
+          mockBackupService.exportDatabaseToFile(),
+        ).thenThrow(Exception('export boom'));
+
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをエクスポート'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('エクスポートに失敗しました'), findsOneWidget);
+        expect(find.textContaining('export boom'), findsOneWidget);
+      });
     });
 
-    testWidgets('データベースインポート確認ダイアログが表示される', (tester) async {
-      when(mockBackupService.importDatabaseFromFile()).thenAnswer(
-        (_) async => const ImportResult(success: true),
-      );
+    group('インポート', () {
+      testWidgets('データベースインポート確認ダイアログが表示される', (tester) async {
+        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
+          (_) async => const ImportResult(success: true),
+        );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: DataStoragePage(backupService: mockBackupService),
-          ),
-        ),
-      );
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをインポート'));
+        await tester.pumpAndSettle();
 
-      await tester.pumpAndSettle();
+        expect(find.text('データベースを復元しますか?'), findsOneWidget);
+        expect(find.text('キャンセル'), findsOneWidget);
+        expect(find.text('復元する'), findsOneWidget);
+      });
 
-      final importButton = find.text('データベースをインポート');
-      expect(importButton, findsOneWidget);
+      testWidgets('成功すると復元完了ダイアログが表示される', (tester) async {
+        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
+          (_) async => const ImportResult(success: true),
+        );
 
-      await tester.tap(importButton);
-      await tester.pumpAndSettle();
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをインポート'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('復元する'));
+        await tester.pumpAndSettle();
 
-      // 確認ダイアログが表示されることを確認
-      expect(find.text('データベースを復元しますか?'), findsOneWidget);
-      expect(find.text('キャンセル'), findsOneWidget);
-      expect(find.text('復元する'), findsOneWidget);
+        expect(find.text('復元が完了しました'), findsOneWidget);
+        verify(mockBackupService.importDatabaseFromFile()).called(1);
+      });
+
+      testWidgets('キャンセルするとスナックバーが表示される', (tester) async {
+        when(mockBackupService.importDatabaseFromFile()).thenAnswer(
+          (_) async => const ImportResult(cancelled: true),
+        );
+
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをインポート'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('復元する'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('インポートをキャンセルしました'), findsOneWidget);
+      });
+
+      testWidgets('失敗すると理由付きのエラーダイアログが表示される', (tester) async {
+        when(
+          mockBackupService.importDatabaseFromFile(),
+        ).thenThrow(Exception('import boom'));
+
+        await pumpPage(tester);
+        await tester.tap(find.text('データベースをインポート'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('復元する'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('インポートに失敗しました'), findsOneWidget);
+        expect(find.textContaining('import boom'), findsOneWidget);
+      });
     });
   });
 }

--- a/test/screens/data_storage_page_test.mocks.dart
+++ b/test/screens/data_storage_page_test.mocks.dart
@@ -23,8 +23,9 @@ import 'package:novelty/services/backup_service.dart' as _i2;
 // ignore_for_file: subtype_of_sealed_class
 // ignore_for_file: invalid_use_of_internal_member
 
-class _FakeImportResult_0 extends _i1.SmartFake implements _i2.ImportResult {
-  _FakeImportResult_0(Object parent, Invocation parentInvocation)
+class _FakeImportStagedResult_0 extends _i1.SmartFake
+    implements _i2.ImportStagedResult {
+  _FakeImportStagedResult_0(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
@@ -45,15 +46,32 @@ class MockBackupService extends _i1.Mock implements _i2.BackupService {
           as _i3.Future<String?>);
 
   @override
-  _i3.Future<_i2.ImportResult> importDatabaseFromFile() =>
+  _i3.Future<String?> exportDatabaseFileDirectly() =>
       (super.noSuchMethod(
-            Invocation.method(#importDatabaseFromFile, []),
-            returnValue: _i3.Future<_i2.ImportResult>.value(
-              _FakeImportResult_0(
+            Invocation.method(#exportDatabaseFileDirectly, []),
+            returnValue: _i3.Future<String?>.value(),
+          )
+          as _i3.Future<String?>);
+
+  @override
+  _i3.Future<_i2.ImportStagedResult> stageImport() =>
+      (super.noSuchMethod(
+            Invocation.method(#stageImport, []),
+            returnValue: _i3.Future<_i2.ImportStagedResult>.value(
+              _FakeImportStagedResult_0(
                 this,
-                Invocation.method(#importDatabaseFromFile, []),
+                Invocation.method(#stageImport, []),
               ),
             ),
           )
-          as _i3.Future<_i2.ImportResult>);
+          as _i3.Future<_i2.ImportStagedResult>);
+
+  @override
+  _i3.Future<void> applyImportSwap(String? pendingFilePath) =>
+      (super.noSuchMethod(
+            Invocation.method(#applyImportSwap, [pendingFilePath]),
+            returnValue: _i3.Future<void>.value(),
+            returnValueForMissingStub: _i3.Future<void>.value(),
+          )
+          as _i3.Future<void>);
 }

--- a/test/screens/migration_ui_test.dart
+++ b/test/screens/migration_ui_test.dart
@@ -85,6 +85,7 @@ void main() {
             error: Exception('test error'),
             onExportDatabase: () async {
               exportCalled = true;
+              return null;
             },
           ),
         ),


### PR DESCRIPTION
## 概要

DBを停止して行う操作(インポート/エクスポート)が「動いているのか分からない」「失敗しても無反応」という問題を解消します。

## 変更内容

### 1. グローバルブロッキング状態の導入
- `DatabaseMaintenanceState`(Idle/Busy)を新設
- 保守操作の実行中はアプリルートのオーバーレイ(`DatabaseMaintenanceOverlay`)で全画面を覆い、配下の操作を物理的に遮断
- 起動時マイグレーションと同じ「アプリ最上位の状態」として統合

### 2. フィードバック契約の必須化
- 成功: 完了ダイアログ
- キャンセル: スナックバー
- 失敗: 理由付きエラーダイアログ(`Exception`だけでなく全throwableを捕捉)
- 無反応で終わるパスを全廃

### 3. インポート/エクスポートの堅牢化
- インポートを `readStream` 経由に変更し、AndroidのSAFで `PlatformFile.path` がnull(content:// URI)になり静かに失敗する問題を解消
- インポート失敗時は `.bak` から元のDBを自動復元
- エクスポート失敗時も必ずエラー表示(従来は静かに失敗し得た)

### 4. インポート後の自動再初期化
- 「アプリを終了して再起動してください」の手動再起動を廃止
- 起動時と同一経路(進捗スプラッシュ→マイグレーション→アプリ復帰)で自動的に再初期化
- リカバリ画面のエクスポートも同一契約に統一

### 5. v17マイグレーション高速化(別コミット)
- FTS再構築をバッチ化(行ごとのINSERT OR REPLACE + rowid解決を廃止)
- 実バックアップ(約900MB)での検証: 約6分→13秒

## テスト
- ブロッキングオーバーレイの表示・操作遮断(test/main_test.dart)
- DataStoragePageの成功/キャンセル/失敗の各フィードバック
- 既存テスト含め全439件パス